### PR TITLE
all tests use session factory

### DIFF
--- a/client-java/test/GraknClientIT.java
+++ b/client-java/test/GraknClientIT.java
@@ -968,8 +968,7 @@ public class GraknClientIT {
             client.keyspaces().delete(tx.keyspace().getName());
         }
 
-        KeyspaceCache keyspaceCache = new KeyspaceCache(server.config());
-        Session newLocalSession = new SessionImpl(localSession.keyspace(), server.config(), keyspaceCache);
+        Session newLocalSession = server.sessionFactory().session(localSession.keyspace());
         try (Transaction tx = newLocalSession.transaction(Transaction.Type.READ)) {
             assertNull(tx.getEntityType("easter"));
         }

--- a/server/src/server/deduplicator/AttributeDeduplicator.java
+++ b/server/src/server/deduplicator/AttributeDeduplicator.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Lists;
 import grakn.core.graql.internal.Schema;
 import grakn.core.server.Transaction;
 import grakn.core.server.session.SessionImpl;
-import grakn.core.server.session.SessionStore;
+import grakn.core.server.session.SessionFactory;
 import grakn.core.server.session.TransactionOLTP;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -48,11 +48,11 @@ public class AttributeDeduplicator {
      * in the duplicates as the "merge target", copying every edges from every "other duplicates" to the merge target, and
      * finally deleting that other duplicates.
      *
-     * @param sessionStore the factory object for accessing the database
+     * @param sessionFactory the factory object for accessing the database
      * @param keyspaceIndexPair the pair containing information about the attribute keyspace and index
      */
-    public static void deduplicate(SessionStore sessionStore, KeyspaceIndexPair keyspaceIndexPair) {
-        SessionImpl session = sessionStore.session(keyspaceIndexPair.keyspace());
+    public static void deduplicate(SessionFactory sessionFactory, KeyspaceIndexPair keyspaceIndexPair) {
+        SessionImpl session = sessionFactory.session(keyspaceIndexPair.keyspace());
         try (TransactionOLTP tx = session.transaction(Transaction.Type.WRITE)) {
             GraphTraversalSource tinker = tx.getTinkerTraversal();
             GraphTraversal<Vertex, Vertex> duplicates = tinker.V().has(Schema.VertexProperty.INDEX.name(), keyspaceIndexPair.index());

--- a/server/src/server/deduplicator/AttributeDeduplicatorDaemon.java
+++ b/server/src/server/deduplicator/AttributeDeduplicatorDaemon.java
@@ -25,7 +25,7 @@ import grakn.core.graql.concept.ConceptId;
 import grakn.core.server.deduplicator.queue.Attribute;
 import grakn.core.server.deduplicator.queue.RocksDbQueue;
 import grakn.core.server.keyspace.Keyspace;
-import grakn.core.server.session.SessionStore;
+import grakn.core.server.session.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +63,7 @@ public class AttributeDeduplicatorDaemon {
 
     private ExecutorService executorServiceForDaemon = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("attribute-deduplicator-daemon-%d").build());
 
-    private SessionStore sessionStore;
+    private SessionFactory sessionFactory;
     private RocksDbQueue queue;
 
     private boolean stopDaemon = false;
@@ -71,13 +71,13 @@ public class AttributeDeduplicatorDaemon {
     /**
      * Instantiates {@link AttributeDeduplicatorDaemon}
      * @param config a reference to an instance of {@link Config} which is initialised from a grakn.properties.
-     * @param sessionStore an {@link SessionStore} instance which provides access to write into the database
+     * @param sessionFactory an {@link SessionFactory} instance which provides access to write into the database
      */
-    public AttributeDeduplicatorDaemon(Config config, SessionStore sessionStore) {
+    public AttributeDeduplicatorDaemon(Config config, SessionFactory sessionFactory) {
         Path dataDir = Paths.get(config.getProperty(ConfigKey.DATA_DIR));
         Path queueDataDir = dataDir.resolve(queueDataDirRelative);
         this.queue = new RocksDbQueue(queueDataDir);
-        this.sessionStore = sessionStore;
+        this.sessionFactory = sessionFactory;
     }
 
     /**
@@ -97,7 +97,7 @@ public class AttributeDeduplicatorDaemon {
     /**
      * Starts a daemon which performs deduplication on incoming attributes in real-time.
      * The thread listens to the {@link RocksDbQueue} queue for incoming attributes and applies
-     * the {@link AttributeDeduplicator#deduplicate(SessionStore, KeyspaceIndexPair)} algorithm.
+     * the {@link AttributeDeduplicator#deduplicate(SessionFactory, KeyspaceIndexPair)} algorithm.
      *
      */
     public CompletableFuture<Void> startDeduplicationDaemon() {
@@ -117,7 +117,7 @@ public class AttributeDeduplicatorDaemon {
 
                     // perform deduplicate for each (keyspace -> value)
                     for (KeyspaceIndexPair keyspaceIndexPair : uniqueKeyValuePairs) {
-                        deduplicate(sessionStore, keyspaceIndexPair);
+                        deduplicate(sessionFactory, keyspaceIndexPair);
                     }
 
                     LOG.trace("new attributes processed.");

--- a/server/src/server/rpc/ServerOpenRequest.java
+++ b/server/src/server/rpc/ServerOpenRequest.java
@@ -21,7 +21,7 @@ package grakn.core.server.rpc;
 import grakn.core.protocol.SessionProto;
 import grakn.core.server.keyspace.Keyspace;
 import grakn.core.server.session.SessionImpl;
-import grakn.core.server.session.SessionStore;
+import grakn.core.server.session.SessionFactory;
 
 /**
  * A request transaction opener for RPC Services. It requires the keyspace and transaction type from the argument object
@@ -29,16 +29,16 @@ import grakn.core.server.session.SessionStore;
  */
 public class ServerOpenRequest implements OpenRequest {
 
-    private final SessionStore sessionStore;
+    private final SessionFactory sessionFactory;
 
-    public ServerOpenRequest(SessionStore sessionStore) {
-        this.sessionStore = sessionStore;
+    public ServerOpenRequest(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
     }
 
     @Override
     public SessionImpl open(SessionProto.Session.Open.Req request) {
         Keyspace keyspace = Keyspace.of(request.getKeyspace());
-        return sessionStore.session(keyspace);
+        return sessionFactory.session(keyspace);
     }
 
 }

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -26,7 +26,6 @@ import grakn.core.server.keyspace.KeyspaceManager;
 import grakn.core.server.session.cache.KeyspaceCache;
 import grakn.core.server.util.LockManager;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 
@@ -35,24 +34,19 @@ import java.util.concurrent.locks.Lock;
  * All components should use this factory so that every time a session to a new keyspace gets created
  * it is possible to also update the Keyspace Store (which tracks all existing keyspaces).
  */
-public class SessionStore {
+public class SessionFactory {
     private final Config config;
     private final KeyspaceManager keyspaceStore;
     private final LockManager lockManager;
 
     private final ConcurrentHashMap<Keyspace, KeyspaceCache> keyspaceCacheMap;
 
-    public static SessionStore create(LockManager lockManager, Config config, KeyspaceManager keyspaceStore) {
-        return new SessionStore(config, lockManager, keyspaceStore);
-    }
-
-    private SessionStore(Config config, LockManager lockManager, KeyspaceManager keyspaceStore) {
+    public SessionFactory(LockManager lockManager, Config config, KeyspaceManager keyspaceStore) {
         this.config = config;
         this.lockManager = lockManager;
         this.keyspaceStore = keyspaceStore;
-        keyspaceCacheMap = new ConcurrentHashMap<>();
+        this.keyspaceCacheMap = new ConcurrentHashMap<>();
     }
-
 
     /**
      * Retrieves the {@link Session} needed to open the {@link Transaction}.
@@ -93,8 +87,6 @@ public class SessionStore {
             lock.unlock();
         }
     }
-
-
 
 
     private static String getLockingKey(Keyspace keyspace) {

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -68,11 +68,12 @@ public class SessionImpl implements Session {
      * using provided Grakn configuration
      *
      * @param keyspace to which keyspace the session should be bound to
-     * @param config   config to be used. If null is supplied, it will be created
+     * @param config   config to be used.
      */
     public SessionImpl(Keyspace keyspace, Config config, KeyspaceCache keyspaceCache) {
         this.keyspace = keyspace;
         this.config = config;
+        // Only save a reference to the factory rather than opening an Hadoop graph immediately because that can be
         // be an expensive operation TODO: refactor in the future
         this.hadoopGraphFactory = new HadoopGraphFactory(this);
         // Open Janus Graph

--- a/test-integration/server/AttributeDeduplicatorIT.java
+++ b/test-integration/server/AttributeDeduplicatorIT.java
@@ -25,7 +25,7 @@ import grakn.core.rule.GraknTestServer;
 import grakn.core.server.deduplicator.AttributeDeduplicator;
 import grakn.core.server.deduplicator.KeyspaceIndexPair;
 import grakn.core.server.session.SessionImpl;
-import grakn.core.server.session.SessionStore;
+import grakn.core.server.session.SessionFactory;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import org.junit.After;
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.hasSize;
 @SuppressWarnings({"CheckReturnValue", "Duplicates"})
 public class AttributeDeduplicatorIT {
     private SessionImpl session;
-    private SessionStore sessionStore;
+    private SessionFactory sessionFactory;
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
@@ -53,7 +53,7 @@ public class AttributeDeduplicatorIT {
     @Before
     public void setUp() {
         session = server.sessionWithNewKeyspace();
-        sessionStore = server.txFactory();
+        sessionFactory = server.sessionFactory();
     }
 
     @After
@@ -79,7 +79,7 @@ public class AttributeDeduplicatorIT {
         }
 
         // perform deduplicate on the instances
-        AttributeDeduplicator.deduplicate(sessionStore, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(testAttributeLabel), testAttributeValue)));
+        AttributeDeduplicator.deduplicate(sessionFactory, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(testAttributeLabel), testAttributeValue)));
 
         // verify if we only have 1 instances after deduplication
         try (TransactionOLTP tx = session.transaction(Transaction.Type.READ)) {
@@ -111,7 +111,7 @@ public class AttributeDeduplicatorIT {
         }
 
         // perform deduplicate on the attribute
-        AttributeDeduplicator.deduplicate(sessionStore, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
+        AttributeDeduplicator.deduplicate(sessionFactory, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
 
         // verify
         try (TransactionOLTP tx = session.transaction(Transaction.Type.READ)) {
@@ -156,9 +156,9 @@ public class AttributeDeduplicatorIT {
         }
 
         // deduplicate
-        AttributeDeduplicator.deduplicate(sessionStore, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
-        AttributeDeduplicator.deduplicate(sessionStore, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownerLabel), ownerValue1)));
-        AttributeDeduplicator.deduplicate(sessionStore, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownerLabel), ownerValue1)));
+        AttributeDeduplicator.deduplicate(sessionFactory, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
+        AttributeDeduplicator.deduplicate(sessionFactory, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownerLabel), ownerValue1)));
+        AttributeDeduplicator.deduplicate(sessionFactory, KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownerLabel), ownerValue1)));
 
         // verify
         try (TransactionOLTP tx = session.transaction(Transaction.Type.READ)) {
@@ -199,7 +199,7 @@ public class AttributeDeduplicatorIT {
         }
 
         // perform deduplicate on the attribute
-        AttributeDeduplicator.deduplicate(sessionStore,
+        AttributeDeduplicator.deduplicate(sessionFactory,
                 KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
 
         // verify
@@ -242,7 +242,7 @@ public class AttributeDeduplicatorIT {
         }
 
         // deduplicate
-        AttributeDeduplicator.deduplicate(sessionStore,
+        AttributeDeduplicator.deduplicate(sessionFactory,
                 KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
 
         // verify
@@ -293,7 +293,7 @@ public class AttributeDeduplicatorIT {
         }
 
         // deduplicate
-        AttributeDeduplicator.deduplicate(sessionStore,
+        AttributeDeduplicator.deduplicate(sessionFactory,
                 KeyspaceIndexPair.create(session.keyspace(), Schema.generateAttributeIndex(Label.of(ownedAttributeLabel), ownedAttributeValue)));
 
         // verify

--- a/test-integration/server/session/BUILD
+++ b/test-integration/server/session/BUILD
@@ -22,7 +22,7 @@ java_test(
     name = "session-it",
     test_class = "grakn.core.server.session.SessionIT",
     srcs = ["SessionIT.java"],
-    deps = ["//server", "//common", "//test-integration/rule:grakn-test-server"],
+    deps = ["//server", "//test-integration/rule:grakn-test-server"],
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 

--- a/test-integration/server/session/SessionIT.java
+++ b/test-integration/server/session/SessionIT.java
@@ -132,8 +132,7 @@ public class SessionIT {
      */
     @Test
     public void sessionsInDifferentThreadsShouldBeAbleToAccessSameKeyspace() throws ExecutionException, InterruptedException {
-        SessionImpl sessionWithLocalCache = server.sessionFactory().session(session.keyspace());
-        Transaction tx1 = sessionWithLocalCache.transaction(WRITE);
+        Transaction tx1 = session.transaction(WRITE);
         tx1.putEntityType("person");
         tx1.commit();
         ExecutorService executor = Executors.newFixedThreadPool(2);

--- a/test-integration/server/session/SessionIT.java
+++ b/test-integration/server/session/SessionIT.java
@@ -18,7 +18,6 @@
 
 package grakn.core.server.session;
 
-import grakn.core.common.config.Config;
 import grakn.core.graql.concept.Label;
 import grakn.core.graql.concept.SchemaConcept;
 import grakn.core.rule.GraknTestServer;
@@ -26,7 +25,6 @@ import grakn.core.server.Transaction;
 import grakn.core.server.exception.SessionException;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.keyspace.Keyspace;
-import grakn.core.server.session.cache.KeyspaceCache;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -52,13 +50,11 @@ public class SessionIT {
     public static final GraknTestServer server = new GraknTestServer();
 
     private SessionImpl session;
-    private Config config;
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
-        config = server.config();
         session = server.sessionWithNewKeyspace();
     }
 
@@ -136,16 +132,16 @@ public class SessionIT {
      */
     @Test
     public void sessionsInDifferentThreadsShouldBeAbleToAccessSameKeyspace() throws ExecutionException, InterruptedException {
-        Transaction tx1 = session.transaction(WRITE);
+        SessionImpl sessionWithLocalCache = server.sessionFactory().session(session.keyspace());
+        Transaction tx1 = sessionWithLocalCache.transaction(WRITE);
         tx1.putEntityType("person");
         tx1.commit();
         ExecutorService executor = Executors.newFixedThreadPool(2);
 
         // shared KeyspaceCache
-        KeyspaceCache keyspaceCache = new KeyspaceCache(config);
 
         executor.submit(() -> {
-            SessionImpl localSession = new SessionImpl(session.keyspace(), config, keyspaceCache);
+            SessionImpl localSession = server.sessionFactory().session(session.keyspace());
             Transaction tx2 = localSession.transaction(WRITE);
             SchemaConcept concept = tx2.getSchemaConcept(Label.of("person"));
             assertEquals("person", concept.label().toString());
@@ -154,7 +150,7 @@ public class SessionIT {
         }).get();
 
         executor.submit(() -> {
-            SessionImpl localSession = new SessionImpl(session.keyspace(), config, keyspaceCache);
+            SessionImpl localSession = server.sessionFactory().session(session.keyspace());
             Transaction tx2 = localSession.transaction(WRITE);
             SchemaConcept concept = tx2.getSchemaConcept(Label.of("person"));
             assertEquals("person", concept.label().toString());
@@ -166,8 +162,7 @@ public class SessionIT {
 
     @Test
     public void whenClosingSession_transactionIsAlsoClosed() {
-        KeyspaceCache keyspaceCache = new KeyspaceCache(config);
-        SessionImpl localSession = new SessionImpl(Keyspace.of("test"), config, keyspaceCache);
+        SessionImpl localSession = server.sessionFactory().session(Keyspace.of("test"));
         Transaction tx1 = localSession.transaction(WRITE);
         assertFalse(tx1.isClosed());
         localSession.close();
@@ -176,8 +171,7 @@ public class SessionIT {
 
     @Test
     public void whenClosingSession_tryingToUseTransactionThrowsException() {
-        KeyspaceCache keyspaceCache = new KeyspaceCache(config);
-        SessionImpl localSession = new SessionImpl(Keyspace.of("test"), config, keyspaceCache);
+        SessionImpl localSession = server.sessionFactory().session(Keyspace.of("test"));
         Transaction tx1 = localSession.transaction(WRITE);
         assertFalse(tx1.isClosed());
         localSession.close();


### PR DESCRIPTION
# Why is this PR needed?

Tests were failing when trying to access SessionImpl without using the correct keyspaceChace

# What does the PR do?

`GraknServerTest` now provides SessionFactory to all tests

# Does it break backwards compatibility?

# List of future improvements not on this PR
