### PR TITLE
Directed adjacency

### DIFF
--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -19,7 +19,8 @@
 package com.vaticle.typedb.core.common.iterator;
 
 import com.vaticle.typedb.common.collection.Either;
-import com.vaticle.typedb.core.common.iterator.sorted.BasedSortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.BaseSortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.BasedSeekableIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.DistinctSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FilteredSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FinaliseSortedIterator;
@@ -129,8 +130,12 @@ public class Iterators {
             return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
         }
 
+        public static <T extends Comparable<T>, ORDER extends Order> SortedIterator<T, ORDER> iterateSorted(ORDER order, List<T> elements) {
+            return new BaseSortedIterator<>(order, elements);
+        }
+
         public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {
-            return new BasedSortedIterator<>(order, set);
+            return new BasedSeekableIterator<>(order, set);
         }
 
         public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> distinct(

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -130,8 +130,8 @@ public class Iterators {
             return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
         }
 
-        public static <T extends Comparable<T>, ORDER extends Order> SortedIterator<T, ORDER> iterateSorted(ORDER order, List<T> elements) {
-            return new BaseSortedIterator<>(order, elements);
+        public static <T extends Comparable<T>, ORDER extends Order> SortedIterator<T, ORDER> iterateSorted(ORDER order, List<T> list) {
+            return new BaseSortedIterator<>(order, list);
         }
 
         public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {

--- a/common/iterator/sorted/BaseSortedIterator.java
+++ b/common/iterator/sorted/BaseSortedIterator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.common.iterator.sorted;
+
+import com.vaticle.typedb.core.common.iterator.Iterators;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+public class BaseSortedIterator<T extends Comparable<? super T>, ORDER extends SortedIterator.Order>
+        extends AbstractSortedIterator<T, ORDER> {
+
+    private final Iterator<T> iterator;
+    private T next;
+
+    public BaseSortedIterator(ORDER order, List<T> source) {
+        super(order);
+        assert isSorted(order, source);
+        this.iterator = source.iterator();
+    }
+
+    private static <T extends Comparable<? super T>, ORD extends SortedIterator.Order> boolean isSorted(ORD order,
+                                                                                                        List<T> source) {
+        if (source.size() <= 1) return true;
+        for (int i = 0; i < source.size(); i++) {
+            T last = source.get(i);
+            T next = source.get(i + 1);
+            if (!order.isValidNext(last, next)) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return (next != null) || fetchAndCheck();
+    }
+
+    private boolean fetchAndCheck() {
+        if (iterator.hasNext()) {
+            next = iterator.next();
+            return true;
+        } else return false;
+    }
+
+    @Override
+    public T next() {
+        if (!hasNext()) throw new NoSuchElementException();
+        T value = next;
+        next = null;
+        return value;
+    }
+
+    @Override
+    public T peek() {
+        if (!hasNext()) throw new NoSuchElementException();
+        return next;
+    }
+
+    @Override
+    public void recycle() {
+    }
+}

--- a/common/iterator/sorted/BaseSortedIterator.java
+++ b/common/iterator/sorted/BaseSortedIterator.java
@@ -18,14 +18,13 @@
 
 package com.vaticle.typedb.core.common.iterator.sorted;
 
-import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
 
-public class BaseSortedIterator<T extends Comparable<? super T>, ORDER extends SortedIterator.Order>
+public class BaseSortedIterator<T extends Comparable<? super T>, ORDER extends Order>
         extends AbstractSortedIterator<T, ORDER> {
 
     private final Iterator<T> iterator;
@@ -37,8 +36,7 @@ public class BaseSortedIterator<T extends Comparable<? super T>, ORDER extends S
         this.iterator = source.iterator();
     }
 
-    private static <T extends Comparable<? super T>, ORD extends SortedIterator.Order> boolean isSorted(ORD order,
-                                                                                                        List<T> source) {
+    private static <T extends Comparable<? super T>, ORD extends Order> boolean isSorted(ORD order, List<T> source) {
         if (source.size() <= 1) return true;
         for (int i = 0; i < source.size(); i++) {
             T last = source.get(i);

--- a/common/iterator/sorted/BasedSeekableIterator.java
+++ b/common/iterator/sorted/BasedSeekableIterator.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 
-public class BasedSortedIterator<T extends Comparable<? super T>, ORDER extends Order>
+public class BasedSeekableIterator<T extends Comparable<? super T>, ORDER extends Order>
         extends AbstractSortedIterator<T, ORDER>
         implements SortedIterator.Seekable<T, ORDER> {
 
@@ -39,7 +39,7 @@ public class BasedSortedIterator<T extends Comparable<? super T>, ORDER extends 
     private T next;
     private T last;
 
-    public BasedSortedIterator(ORDER order, NavigableSet<T> source) {
+    public BasedSeekableIterator(ORDER order, NavigableSet<T> source) {
         super(order);
         this.source = source;
         this.iterator = order.iterateOrdered(source);

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -62,7 +62,6 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.loop;
 import static com.vaticle.typedb.core.common.iterator.Iterators.tree;
-import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS_KEY;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.RELATES;

--- a/graph/adjacency/ComparableEdge.java
+++ b/graph/adjacency/ComparableEdge.java
@@ -23,53 +23,52 @@ import com.vaticle.typedb.core.graph.edge.ThingEdge;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.iid.EdgeIID;
 
-public abstract class DirectedEdge {
+public abstract class ComparableEdge {
 
-    public abstract Edge<?, ?, ?> get();
+    public abstract Edge<?, ?, ?> edge();
 
-    public abstract EdgeIID<?, ?, ?, ?> directedIID();
+    public abstract EdgeIID<?, ?, ?, ?> iid();
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        final DirectedEdge that = (DirectedEdge) o;
-        return directedIID().equals(that.directedIID());
+        final ComparableEdge that = (ComparableEdge) o;
+        return iid().equals(that.iid());
     }
 
     @Override
     public int hashCode() {
-        return directedIID().hashCode();
+        return iid().hashCode();
     }
 
-    abstract static class Type extends DirectedEdge implements Comparable<Type> {
+    abstract static class Type extends ComparableEdge implements Comparable<Type> {
+
         final TypeEdge edge;
 
         Type(TypeEdge edge) {
             this.edge = edge;
         }
 
-        public TypeEdge get() {
+        public TypeEdge edge() {
             return edge;
         }
 
         @Override
-        public EdgeIID.Type directedIID() {
-            return null;
-        }
+        public abstract EdgeIID.Type iid();
 
-        public static Type in(TypeEdge edge) {
+        public static Type byInIID(TypeEdge edge) {
             return create(edge, edge.inIID());
         }
 
-        public static Type out(TypeEdge edge) {
+        public static Type byOutIID(TypeEdge edge) {
             return create(edge, edge.outIID());
         }
 
         private static Type create(TypeEdge edge, EdgeIID.Type iid) {
             return new Type(edge) {
                 @Override
-                public EdgeIID.Type directedIID() {
+                public EdgeIID.Type iid() {
                     return iid;
                 }
             };
@@ -77,38 +76,36 @@ public abstract class DirectedEdge {
 
         @Override
         public int compareTo(Type other) {
-            return directedIID().compareTo(other.directedIID());
+            return iid().compareTo(other.iid());
         }
     }
 
-    public abstract static class Thing extends DirectedEdge implements Comparable<Thing> {
+    public abstract static class Thing extends ComparableEdge implements Comparable<Thing> {
         final ThingEdge edge;
 
         Thing(ThingEdge edge) {
             this.edge = edge;
         }
 
-        public ThingEdge get() {
+        public ThingEdge edge() {
             return edge;
         }
 
         @Override
-        public EdgeIID.Thing directedIID() {
-            return null;
-        }
+        public abstract EdgeIID.Thing iid();
 
-        public static Thing in(ThingEdge edge) {
+        public static Thing byInIID(ThingEdge edge) {
             return create(edge, edge.inIID());
         }
 
-        public static Thing out(ThingEdge edge) {
+        public static Thing byOutIID(ThingEdge edge) {
             return create(edge, edge.outIID());
         }
 
         private static Thing create(ThingEdge edge, EdgeIID.Thing iid) {
             return new Thing(edge) {
                 @Override
-                public EdgeIID.Thing directedIID() {
+                public EdgeIID.Thing iid() {
                     return iid;
                 }
             };
@@ -116,7 +113,7 @@ public abstract class DirectedEdge {
 
         @Override
         public int compareTo(Thing other) {
-            return directedIID().compareTo(other.directedIID());
+            return iid().compareTo(other.iid());
         }
     }
 }

--- a/graph/adjacency/DirectedEdge.java
+++ b/graph/adjacency/DirectedEdge.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.graph.adjacency;
+
+import com.vaticle.typedb.core.graph.edge.Edge;
+import com.vaticle.typedb.core.graph.edge.ThingEdge;
+import com.vaticle.typedb.core.graph.edge.TypeEdge;
+import com.vaticle.typedb.core.graph.iid.EdgeIID;
+
+public abstract class DirectedEdge {
+
+    public abstract Edge<?, ?, ?> get();
+
+    public abstract EdgeIID<?, ?, ?, ?> directedIID();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final DirectedEdge that = (DirectedEdge) o;
+        return directedIID().equals(that.directedIID());
+    }
+
+    @Override
+    public int hashCode() {
+        return directedIID().hashCode();
+    }
+
+    abstract static class Type extends DirectedEdge implements Comparable<Type> {
+        final TypeEdge edge;
+
+        Type(TypeEdge edge) {
+            this.edge = edge;
+        }
+
+        public TypeEdge get() {
+            return edge;
+        }
+
+        @Override
+        public EdgeIID.Type directedIID() {
+            return null;
+        }
+
+        public static Type in(TypeEdge edge) {
+            return create(edge, edge.inIID());
+        }
+
+        public static Type out(TypeEdge edge) {
+            return create(edge, edge.outIID());
+        }
+
+        private static Type create(TypeEdge edge, EdgeIID.Type iid) {
+            return new Type(edge) {
+                @Override
+                public EdgeIID.Type directedIID() {
+                    return iid;
+                }
+            };
+        }
+
+        @Override
+        public int compareTo(Type other) {
+            return directedIID().compareTo(other.directedIID());
+        }
+    }
+
+    public abstract static class Thing extends DirectedEdge implements Comparable<Thing> {
+        final ThingEdge edge;
+
+        Thing(ThingEdge edge) {
+            this.edge = edge;
+        }
+
+        public ThingEdge get() {
+            return edge;
+        }
+
+        @Override
+        public EdgeIID.Thing directedIID() {
+            return null;
+        }
+
+        public static Thing in(ThingEdge edge) {
+            return create(edge, edge.inIID());
+        }
+
+        public static Thing out(ThingEdge edge) {
+            return create(edge, edge.outIID());
+        }
+
+        private static Thing create(ThingEdge edge, EdgeIID.Thing iid) {
+            return new Thing(edge) {
+                @Override
+                public EdgeIID.Thing directedIID() {
+                    return iid;
+                }
+            };
+        }
+
+        @Override
+        public int compareTo(Thing other) {
+            return directedIID().compareTo(other.directedIID());
+        }
+    }
+}

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -38,11 +38,11 @@ public interface ThingAdjacency {
      * @param encoding the {@code Encoding} to filter the type of edges
      * @return an {@code SortedIteratorBuilder} to retrieve vertices of a set of edges.
      */
-    SortedIteratorBuilder edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead);
+    SortedEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead);
 
-    SortedIteratorBuilder edge(Encoding.Edge.Thing.Optimised encoding, TypeVertex roleType, IID... lookAhead);
+    SortedEdgeIterator edge(Encoding.Edge.Thing.Optimised encoding, TypeVertex roleType, IID... lookAhead);
 
-    IteratorBuilder edge(Encoding.Edge.Thing.Optimised encoding);
+    EdgeIterator edge(Encoding.Edge.Thing.Optimised encoding);
 
     /**
      * Returns an edge of type {@code encoding} that connects to an {@code adjacent}
@@ -65,7 +65,8 @@ public interface ThingAdjacency {
      */
     ThingEdge edge(Encoding.Edge.Thing encoding, ThingVertex adjacent, ThingVertex optimised);
 
-    interface IteratorBuilder {
+    // TODO we should end up with only seekable iterators available
+    interface EdgeIterator {
 
         FunctionalIterator<ThingVertex> from();
 
@@ -74,13 +75,14 @@ public interface ThingAdjacency {
         FunctionalIterator<ThingEdge> get();
     }
 
-    interface SortedIteratorBuilder {
+    interface SortedEdgeIterator {
 
         SortedIterator<ThingVertex, Order.Asc> from();
 
         SortedIterator<ThingVertex, Order.Asc> to();
 
-        SortedIterator.Seekable<DirectedEdge.Thing, Order.Asc> get();
+        // TODO ComparableEdge should be an implementation detail of Adjacencies
+        SortedIterator.Seekable<ComparableEdge.Thing, Order.Asc> get();
     }
 
     interface Write extends ThingAdjacency {
@@ -145,7 +147,5 @@ public interface ThingAdjacency {
         void commit();
 
     }
-
-    DirectedEdge asDirected(ThingEdge edge);
 
 }

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -29,18 +29,19 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
 public interface ThingAdjacency {
 
-    /**
-     * Returns an {@code IteratorBuilder} to retrieve vertices of a set of non-optimised edges.
-     *
-     * This method allows us to traverse the graph, by going from one vertex to
-     * another, that are connected by edges that match the provided {@code encoding}.
-     *
-     * @param encoding the {@code Encoding} to filter the type of edges
-     * @return an {@code SortedIteratorBuilder} to retrieve vertices of a set of edges.
-     */
-    SortedEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead);
+    interface In extends ThingAdjacency {
 
-    SortedEdgeIterator edge(Encoding.Edge.Thing.Optimised encoding, TypeVertex roleType, IID... lookAhead);
+        SortedEdgeIterator.Ins edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead);
+
+        SortedEdgeIterator.Ins edge(Encoding.Edge.Thing.Optimised encoding, TypeVertex roleType, IID... lookAhead);
+    }
+
+    interface Out extends ThingAdjacency {
+
+        SortedEdgeIterator.Outs edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead);
+
+        SortedEdgeIterator.Outs edge(Encoding.Edge.Thing.Optimised encoding, TypeVertex roleType, IID... lookAhead);
+    }
 
     EdgeIterator edge(Encoding.Edge.Thing.Optimised encoding);
 
@@ -77,12 +78,22 @@ public interface ThingAdjacency {
 
     interface SortedEdgeIterator {
 
-        SortedIterator<ThingVertex, Order.Asc> from();
-
-        SortedIterator<ThingVertex, Order.Asc> to();
-
         // TODO ComparableEdge should be an implementation detail of Adjacencies
         SortedIterator.Seekable<ComparableEdge.Thing, Order.Asc> get();
+
+        interface Ins extends SortedEdgeIterator {
+
+            SortedIterator<ThingVertex, Order.Asc> from();
+
+            SortedIterator.Seekable<ThingVertex, Order.Asc> to();
+        }
+
+        interface Outs extends SortedEdgeIterator {
+
+            SortedIterator.Seekable<ThingVertex, Order.Asc> from();
+
+            SortedIterator<ThingVertex, Order.Asc> to();
+        }
     }
 
     interface Write extends ThingAdjacency {

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -83,20 +83,28 @@ public interface ThingAdjacency {
 
         interface Ins extends SortedEdgeIterator {
 
-            SortedIterator<ThingVertex, Order.Asc> from();
-
-            SortedIterator.Seekable<ThingVertex, Order.Asc> to();
-        }
-
-        interface Outs extends SortedEdgeIterator {
-
             SortedIterator.Seekable<ThingVertex, Order.Asc> from();
 
             SortedIterator<ThingVertex, Order.Asc> to();
         }
+
+        interface Outs extends SortedEdgeIterator {
+
+            SortedIterator<ThingVertex, Order.Asc> from();
+
+            SortedIterator.Seekable<ThingVertex, Order.Asc> to();
+        }
     }
 
     interface Write extends ThingAdjacency {
+
+        interface In extends Write, ThingAdjacency.In {
+
+        }
+
+        interface Out extends Write, ThingAdjacency.Out {
+
+        }
 
         /**
          * Puts an adjacent vertex over an edge with a given encoding.

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -23,7 +23,6 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.ThingEdge;
-import com.vaticle.typedb.core.graph.iid.EdgeIID;
 import com.vaticle.typedb.core.graph.iid.IID;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
@@ -81,7 +80,7 @@ public interface ThingAdjacency {
 
         SortedIterator<ThingVertex, Order.Asc> to();
 
-        SortedIterator.Seekable<DirectedEdge, Order.Asc> get();
+        SortedIterator.Seekable<DirectedEdge.Thing, Order.Asc> get();
     }
 
     interface Write extends ThingAdjacency {
@@ -149,53 +148,4 @@ public interface ThingAdjacency {
 
     DirectedEdge asDirected(ThingEdge edge);
 
-    abstract class DirectedEdge implements Comparable<DirectedEdge> {
-
-        public final ThingEdge edge;
-
-        DirectedEdge(ThingEdge edge) {
-            this.edge = edge;
-        }
-
-        public abstract EdgeIID.Thing iid();
-
-        public static DirectedEdge in(ThingEdge edge) {
-            return directedEdge(edge, edge.inIID());
-        }
-
-        public static DirectedEdge out(ThingEdge edge) {
-            return directedEdge(edge, edge.outIID());
-        }
-
-        private static DirectedEdge directedEdge(ThingEdge edge, EdgeIID.Thing iid) {
-            return new DirectedEdge(edge) {
-                @Override
-                public EdgeIID.Thing iid() {
-                    return iid;
-                }
-            };
-        }
-
-        public ThingEdge get() {
-            return edge;
-        }
-
-        @Override
-        public int compareTo(DirectedEdge other) {
-            return iid().compareTo(other.iid());
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            final DirectedEdge that = (DirectedEdge) o;
-            return edge.equals(that.edge);
-        }
-
-        @Override
-        public int hashCode() {
-            return edge.hashCode();
-        }
-    }
 }

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -166,5 +166,4 @@ public interface ThingAdjacency {
         void commit();
 
     }
-
 }

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -19,9 +19,6 @@
 package com.vaticle.typedb.core.graph.adjacency;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -67,7 +67,6 @@ public interface TypeAdjacency {
 
     void commit();
 
-
     /**
      * When used in combination with purely retrieving type edges (by infix encoding),
      * this iterator builder performs safe vertex downcasts at both ends of the edge

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -19,6 +19,9 @@
 package com.vaticle.typedb.core.graph.adjacency;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -40,13 +40,11 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Predicate;
 
 import static com.vaticle.typedb.common.collection.Collections.list;

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -53,6 +53,7 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSo
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
+import static com.vaticle.typedb.core.graph.adjacency.ThingAdjacency.*;
 import static com.vaticle.typedb.core.graph.adjacency.ThingAdjacency.SortedEdgeIterator.Ins;
 import static com.vaticle.typedb.core.graph.adjacency.ThingAdjacency.SortedEdgeIterator.Outs;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Thing.Optimised.ROLEPLAYER;

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -40,7 +40,6 @@ import java.util.function.Predicate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
-import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 
 public abstract class TypeAdjacencyImpl implements TypeAdjacency {
 

--- a/graph/structure/impl/RuleStructureImpl.java
+++ b/graph/structure/impl/RuleStructureImpl.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.vaticle.typedb.core.common.collection.ByteArray.encodeString;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
-import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.LABEL;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.THEN;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.WHEN;

--- a/graph/vertex/ThingVertex.java
+++ b/graph/vertex/ThingVertex.java
@@ -52,14 +52,14 @@ public interface ThingVertex extends Vertex<VertexIID.Thing, Encoding.Vertex.Thi
      *
      * @return the {@code ThingAdjacency} set of outgoing edges
      */
-    ThingAdjacency outs();
+    ThingAdjacency.Out outs();
 
     /**
      * Returns the {@code ThingAdjacency} set of incoming edges.
      *
      * @return the {@code ThingAdjacency} set of incoming edges
      */
-    ThingAdjacency ins();
+    ThingAdjacency.In ins();
 
     /**
      * Returns true if this {@code ThingVertex} is a result of inference.
@@ -95,14 +95,14 @@ public interface ThingVertex extends Vertex<VertexIID.Thing, Encoding.Vertex.Thi
          *
          * @return the {@code ThingAdjacency} set of outgoing edges
          */
-        ThingAdjacency.Write outs();
+        ThingAdjacency.Write.Out outs();
 
         /**
          * Returns the {@code ThingAdjacency} set of incoming edges.
          *
          * @return the {@code ThingAdjacency} set of incoming edges
          */
-        ThingAdjacency.Write ins();
+        ThingAdjacency.Write.In ins();
 
         void setModified();
 

--- a/graph/vertex/TypeVertex.java
+++ b/graph/vertex/TypeVertex.java
@@ -27,7 +27,7 @@ import com.vaticle.typedb.core.graph.iid.VertexIID;
 
 import java.util.regex.Pattern;
 
-public interface TypeVertex extends Vertex<VertexIID.Type, Encoding.Vertex.Type> {
+public interface TypeVertex extends Vertex<VertexIID.Type, Encoding.Vertex.Type>, Comparable<TypeVertex> {
     /**
      * @return the {@code Graph} containing all Schema elements
      */

--- a/graph/vertex/impl/AttributeVertexImpl.java
+++ b/graph/vertex/impl/AttributeVertexImpl.java
@@ -283,8 +283,13 @@ public abstract class AttributeVertexImpl {
         }
 
         @Override
-        protected ThingAdjacency.Write newAdjacency(Encoding.Direction.Adjacency direction) {
-            return new ThingAdjacencyImpl.Write.Persisted(this, direction);
+        protected ThingAdjacency.Write.In newInAdjacency() {
+            return new ThingAdjacencyImpl.Write.Persisted.In(this);
+        }
+
+        @Override
+        protected ThingAdjacency.Write.Out newOutAdjacency() {
+            return new ThingAdjacencyImpl.Write.Persisted.Out(this);
         }
 
         @Override

--- a/graph/vertex/impl/ThingVertexImpl.java
+++ b/graph/vertex/impl/ThingVertexImpl.java
@@ -99,7 +99,7 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
 
     @Override
     public int compareTo(ThingVertex o) {
-        return iid.bytes().compareTo(o.iid().bytes());
+        return iid.compareTo(o.iid());
     }
 
     public static class Read extends ThingVertexImpl {

--- a/graph/vertex/impl/ThingVertexImpl.java
+++ b/graph/vertex/impl/ThingVertexImpl.java
@@ -104,13 +104,13 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
 
     public static class Read extends ThingVertexImpl {
 
-        protected final ThingAdjacency outs;
-        protected final ThingAdjacency ins;
+        protected final ThingAdjacency.Out outs;
+        protected final ThingAdjacency.In ins;
 
         public Read(ThingGraph graph, VertexIID.Thing iid) {
             super(graph, iid);
-            this.outs = new ThingAdjacencyImpl.Read(this, Encoding.Direction.Adjacency.OUT);
-            this.ins = new ThingAdjacencyImpl.Read(this, Encoding.Direction.Adjacency.IN);
+            this.outs = new ThingAdjacencyImpl.Read.Out(this);
+            this.ins = new ThingAdjacencyImpl.Read.In(this);
         }
 
         public static ThingVertexImpl.Read of(ThingGraph graph, VertexIID.Thing iid) {
@@ -127,17 +127,17 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
         }
 
         @Override
-        public ThingAdjacency ins() {
-            return ins;
-        }
-
-        @Override
         public ThingVertex.Write toWrite() {
             return graph.convertToWritable(iid);
         }
 
         @Override
-        public ThingAdjacency outs() {
+        public ThingAdjacency.In ins() {
+            return ins;
+        }
+
+        @Override
+        public ThingAdjacency.Out outs() {
             return outs;
         }
 
@@ -154,8 +154,8 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
 
     public static abstract class Write extends ThingVertexImpl implements ThingVertex.Write {
 
-        protected final ThingAdjacency.Write outs;
-        protected final ThingAdjacency.Write ins;
+        protected final ThingAdjacency.Write.Out outs;
+        protected final ThingAdjacency.Write.In ins;
         protected final AtomicBoolean isDeleted;
         protected boolean isModified;
 
@@ -163,8 +163,8 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             super(graph, iid);
             this.isModified = false;
             this.isDeleted = new AtomicBoolean(false);
-            this.outs = newAdjacency(Encoding.Direction.Adjacency.OUT);
-            this.ins = newAdjacency(Encoding.Direction.Adjacency.IN);
+            this.outs = newOutAdjacency();
+            this.ins = newInAdjacency();
         }
 
         public static ThingVertexImpl.Write of(ThingGraph graph, VertexIID.Thing iid) {
@@ -175,15 +175,17 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             }
         }
 
-        protected abstract ThingAdjacency.Write newAdjacency(Encoding.Direction.Adjacency direction);
+        protected abstract ThingAdjacency.Write.In newInAdjacency();
+
+        protected abstract ThingAdjacency.Write.Out newOutAdjacency();
 
         @Override
-        public ThingAdjacency.Write outs() {
+        public ThingAdjacency.Write.Out outs() {
             return outs;
         }
 
         @Override
-        public ThingAdjacency.Write ins() {
+        public ThingAdjacency.Write.In ins() {
             return ins;
         }
 
@@ -253,8 +255,13 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             }
 
             @Override
-            protected ThingAdjacency.Write newAdjacency(Encoding.Direction.Adjacency direction) {
-                return new ThingAdjacencyImpl.Write.Buffered(this, direction);
+            protected ThingAdjacency.Write.In newInAdjacency() {
+                return new ThingAdjacencyImpl.Write.Buffered.In(this);
+            }
+
+            @Override
+            protected ThingAdjacency.Write.Out newOutAdjacency() {
+                return new ThingAdjacencyImpl.Write.Buffered.Out(this);
             }
 
             @Override
@@ -300,8 +307,13 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             }
 
             @Override
-            protected ThingAdjacency.Write newAdjacency(Encoding.Direction.Adjacency direction) {
-                return new ThingAdjacencyImpl.Write.Persisted(this, direction);
+            protected ThingAdjacency.Write.In newInAdjacency() {
+                return new ThingAdjacencyImpl.Write.Persisted.In(this);
+            }
+
+            @Override
+            protected ThingAdjacency.Write.Out newOutAdjacency() {
+                return new ThingAdjacencyImpl.Write.Persisted.Out(this);
             }
 
             @Override

--- a/graph/vertex/impl/TypeVertexImpl.java
+++ b/graph/vertex/impl/TypeVertexImpl.java
@@ -263,6 +263,11 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         ins.commit();
     }
 
+    @Override
+    public int compareTo(TypeVertex o) {
+        return iid.compareTo(o.iid());
+    }
+
     public static class Buffered extends TypeVertexImpl {
 
         private final AtomicBoolean isCommitted;

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -23,7 +23,7 @@ import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.TypeGraph;
-import com.vaticle.typedb.core.graph.adjacency.ThingAdjacency;
+import com.vaticle.typedb.core.graph.adjacency.DirectedEdge;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.ThingEdge;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
@@ -604,7 +604,6 @@ public abstract class ProcedureEdge<
                         if (isKey) return attType.ins().edge(OWNS_KEY).from();
                         else return link(attType.ins().edge(OWNS).from(), attType.ins().edge(OWNS_KEY).from());
                     }
-
 
                     private FunctionalIterator<TypeVertex> ownersOfAttType(TypeVertex attType) {
                         return declaredOwnersOfAttType(attType).flatMap(owner -> tree(owner, o ->
@@ -1215,7 +1214,7 @@ public abstract class ProcedureEdge<
                                 iter = resolveRoleTypesIter.flatMap(
                                         rt -> rel.outs()
                                                 .edge(ROLEPLAYER, rt, player.iid().prefix(), player.iid().type()).get()
-                                                .map(ThingAdjacency.DirectedEdge::get)
+                                                .map(DirectedEdge.Thing::get)
                                 ).filter(e -> e.to().equals(player));
                             } else if (!to.props().types().isEmpty()) {
                                 filteredTypes = true;
@@ -1223,12 +1222,12 @@ public abstract class ProcedureEdge<
                                         rt -> iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).noNulls()
                                                 .flatMap(t -> rel.outs()
                                                         .edge(ROLEPLAYER, rt, PrefixIID.of(t.encoding().instance()), t.iid()).get()
-                                                        .map(ThingAdjacency.DirectedEdge::get))
+                                                        .map(DirectedEdge.Thing::get))
                                 );
                             } else {
                                 iter = resolveRoleTypesIter.flatMap(rt -> rel.outs()
                                         .edge(ROLEPLAYER, rt).get()
-                                        .map(ThingAdjacency.DirectedEdge::get));
+                                        .map(DirectedEdge.Thing::get));
                             }
                         } else {
                             iter = rel.outs().edge(ROLEPLAYER).get();
@@ -1249,7 +1248,7 @@ public abstract class ProcedureEdge<
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> rel.outs()
                                             .edge(ROLEPLAYER, rt, player.iid().prefix(), player.iid().type()).get()
-                                            .map(ThingAdjacency.DirectedEdge::get)
+                                            .map(DirectedEdge.Thing::get)
                                             .filter(e -> e.to().equals(player) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {
@@ -1286,7 +1285,7 @@ public abstract class ProcedureEdge<
                                 iter = resolveRoleTypesIter.flatMap(
                                         rt -> player.ins()
                                                 .edge(ROLEPLAYER, rt, relation.iid().prefix(), relation.iid().type()).get()
-                                                .map(ThingAdjacency.DirectedEdge::get)
+                                                .map(DirectedEdge.Thing::get)
                                                 .filter(r -> r.from().equals(relation)));
                             } else if (!to.props().types().isEmpty()) {
                                 filteredTypes = true;
@@ -1294,9 +1293,11 @@ public abstract class ProcedureEdge<
                                         rt -> iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).noNulls()
                                                 .flatMap(t -> player.ins()
                                                         .edge(ROLEPLAYER, rt, PrefixIID.of(t.encoding().instance()), t.iid()).get()
-                                                        .map(ThingAdjacency.DirectedEdge::get)));
+                                                        .map(DirectedEdge.Thing::get)));
                             } else {
-                                iter = resolveRoleTypesIter.flatMap(rt -> player.ins().edge(ROLEPLAYER, rt).get().map(ThingAdjacency.DirectedEdge::get));
+                                iter = resolveRoleTypesIter.flatMap(
+                                        rt -> player.ins().edge(ROLEPLAYER, rt).get().map(DirectedEdge.Thing::get)
+                                );
                             }
                         } else {
                             iter = player.ins().edge(ROLEPLAYER).get();
@@ -1315,7 +1316,7 @@ public abstract class ProcedureEdge<
                         if (!roleTypes.isEmpty()) {
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> player.ins().edge(ROLEPLAYER, rt, rel.iid().prefix(), rel.iid().type()).get()
-                                            .map(ThingAdjacency.DirectedEdge::get)
+                                            .map(DirectedEdge.Thing::get)
                                             .filter(e -> e.from().equals(rel) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -53,9 +53,13 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNSUPPORTED_OPERATION;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
+import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
+import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.loop;
+import static com.vaticle.typedb.core.common.iterator.Iterators.single;
 import static com.vaticle.typedb.core.common.iterator.Iterators.single;
 import static com.vaticle.typedb.core.common.iterator.Iterators.tree;
 import static com.vaticle.typedb.core.graph.common.Encoding.Direction.Edge.BACKWARD;

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -23,7 +23,7 @@ import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.TypeGraph;
-import com.vaticle.typedb.core.graph.adjacency.DirectedEdge;
+import com.vaticle.typedb.core.graph.adjacency.ComparableEdge;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.ThingEdge;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
@@ -1214,7 +1214,7 @@ public abstract class ProcedureEdge<
                                 iter = resolveRoleTypesIter.flatMap(
                                         rt -> rel.outs()
                                                 .edge(ROLEPLAYER, rt, player.iid().prefix(), player.iid().type()).get()
-                                                .map(DirectedEdge.Thing::get)
+                                                .map(ComparableEdge.Thing::edge)
                                 ).filter(e -> e.to().equals(player));
                             } else if (!to.props().types().isEmpty()) {
                                 filteredTypes = true;
@@ -1222,12 +1222,12 @@ public abstract class ProcedureEdge<
                                         rt -> iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).noNulls()
                                                 .flatMap(t -> rel.outs()
                                                         .edge(ROLEPLAYER, rt, PrefixIID.of(t.encoding().instance()), t.iid()).get()
-                                                        .map(DirectedEdge.Thing::get))
+                                                        .map(ComparableEdge.Thing::edge))
                                 );
                             } else {
                                 iter = resolveRoleTypesIter.flatMap(rt -> rel.outs()
                                         .edge(ROLEPLAYER, rt).get()
-                                        .map(DirectedEdge.Thing::get));
+                                        .map(ComparableEdge.Thing::edge));
                             }
                         } else {
                             iter = rel.outs().edge(ROLEPLAYER).get();
@@ -1248,7 +1248,7 @@ public abstract class ProcedureEdge<
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> rel.outs()
                                             .edge(ROLEPLAYER, rt, player.iid().prefix(), player.iid().type()).get()
-                                            .map(DirectedEdge.Thing::get)
+                                            .map(ComparableEdge.Thing::edge)
                                             .filter(e -> e.to().equals(player) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {
@@ -1285,7 +1285,7 @@ public abstract class ProcedureEdge<
                                 iter = resolveRoleTypesIter.flatMap(
                                         rt -> player.ins()
                                                 .edge(ROLEPLAYER, rt, relation.iid().prefix(), relation.iid().type()).get()
-                                                .map(DirectedEdge.Thing::get)
+                                                .map(ComparableEdge.Thing::edge)
                                                 .filter(r -> r.from().equals(relation)));
                             } else if (!to.props().types().isEmpty()) {
                                 filteredTypes = true;
@@ -1293,10 +1293,10 @@ public abstract class ProcedureEdge<
                                         rt -> iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).noNulls()
                                                 .flatMap(t -> player.ins()
                                                         .edge(ROLEPLAYER, rt, PrefixIID.of(t.encoding().instance()), t.iid()).get()
-                                                        .map(DirectedEdge.Thing::get)));
+                                                        .map(ComparableEdge.Thing::edge)));
                             } else {
                                 iter = resolveRoleTypesIter.flatMap(
-                                        rt -> player.ins().edge(ROLEPLAYER, rt).get().map(DirectedEdge.Thing::get)
+                                        rt -> player.ins().edge(ROLEPLAYER, rt).get().map(ComparableEdge.Thing::edge)
                                 );
                             }
                         } else {
@@ -1316,7 +1316,7 @@ public abstract class ProcedureEdge<
                         if (!roleTypes.isEmpty()) {
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> player.ins().edge(ROLEPLAYER, rt, rel.iid().prefix(), rel.iid().type()).get()
-                                            .map(DirectedEdge.Thing::get)
+                                            .map(ComparableEdge.Thing::edge)
                                             .filter(e -> e.from().equals(rel) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {

--- a/traversal/scanner/RelationIterator.java
+++ b/traversal/scanner/RelationIterator.java
@@ -28,7 +28,7 @@ import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
-import com.vaticle.typedb.core.graph.adjacency.ThingAdjacency;
+import com.vaticle.typedb.core.graph.adjacency.DirectedEdge;
 import com.vaticle.typedb.core.graph.edge.impl.ThingEdgeImpl;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
@@ -207,13 +207,13 @@ public class RelationIterator extends AbstractFunctionalIterator<VertexMap> {
         ThingVertex player = answer.get(edge.to().id().asVariable().asRetrievable()).asThing();
         return Iterators.Sorted.merge(ASC, iterate(edge.asNative().asRolePlayer().types()).map(roleLabel -> {
             TypeVertex roleVertex = graphMgr.schema().getType(roleLabel);
-            Seekable<KeyValue<ThingVertex, ThingVertex>, Order.Asc> relRoles = player.ins().edge(ROLEPLAYER, roleVertex).get().filter(
-                    directedEdge -> relationTypes.contains(directedEdge.get().from().type().properLabel())
-            ).mapSorted(
-                    ASC,
-                    dirEdge -> new KeyValue<>(dirEdge.get().from(), dirEdge.get().optimised().get()),
-                    relRole -> ThingAdjacency.DirectedEdge.in(new ThingEdgeImpl.Target(ROLEPLAYER, relRole.key(), player, roleVertex))
-            );
+            Seekable<KeyValue<ThingVertex, ThingVertex>, Order.Asc> relRoles = player.ins().edge(ROLEPLAYER, roleVertex)
+                    .get().filter(directedEdge -> relationTypes.contains(directedEdge.get().from().type().properLabel()))
+                    .mapSorted(
+                            ASC,
+                            dirEdge -> new KeyValue<>(dirEdge.get().from(), dirEdge.get().optimised().get()),
+                            relRole -> DirectedEdge.Thing.in(new ThingEdgeImpl.Target(ROLEPLAYER, relRole.key(), player, roleVertex))
+                    );
             return relRoles;
         })).filter(relRole -> !scoped.contains(relRole.value())).mapSorted(
                 ASC,

--- a/traversal/scanner/RelationIterator.java
+++ b/traversal/scanner/RelationIterator.java
@@ -28,7 +28,7 @@ import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
-import com.vaticle.typedb.core.graph.adjacency.DirectedEdge;
+import com.vaticle.typedb.core.graph.adjacency.ComparableEdge;
 import com.vaticle.typedb.core.graph.edge.impl.ThingEdgeImpl;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
@@ -208,11 +208,11 @@ public class RelationIterator extends AbstractFunctionalIterator<VertexMap> {
         return Iterators.Sorted.merge(ASC, iterate(edge.asNative().asRolePlayer().types()).map(roleLabel -> {
             TypeVertex roleVertex = graphMgr.schema().getType(roleLabel);
             Seekable<KeyValue<ThingVertex, ThingVertex>, Order.Asc> relRoles = player.ins().edge(ROLEPLAYER, roleVertex)
-                    .get().filter(directedEdge -> relationTypes.contains(directedEdge.get().from().type().properLabel()))
+                    .get().filter(directedEdge -> relationTypes.contains(directedEdge.edge().from().type().properLabel()))
                     .mapSorted(
                             ASC,
-                            dirEdge -> new KeyValue<>(dirEdge.get().from(), dirEdge.get().optimised().get()),
-                            relRole -> DirectedEdge.Thing.in(new ThingEdgeImpl.Target(ROLEPLAYER, relRole.key(), player, roleVertex))
+                            dirEdge -> new KeyValue<>(dirEdge.edge().from(), dirEdge.edge().optimised().get()),
+                            relRole -> ComparableEdge.Thing.byInIID(new ThingEdgeImpl.Target(ROLEPLAYER, relRole.key(), player, roleVertex))
                     );
             return relRoles;
         })).filter(relRole -> !scoped.contains(relRole.value())).mapSorted(


### PR DESCRIPTION
## What is the goal of this PR?

Vertex adjacencies are now more type safe: they have different types and method signatures depending on whether they are an `In` or `Out` adjacency.

## What are the changes implemented in this PR?

* Split `ThingAdjacency` into `In` and `Out` for both `Read`/`Write` adjacency types