### PR TITLE
Allow anonymous type variables for relation role types

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -353,16 +353,14 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
         public static final ThingWrite AMBIGUOUS_TYPE_VARIABLE_IN_INSERT =
                 new ThingWrite(16, "Ambiguous type variable '%s' in insert could be any of the types '%s'. Insert variables must represent exactly 1 type.");
-//        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =  // TODO
-//                new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =
                 new ThingWrite(18, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE =
                 new ThingWrite(19, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
         public static final ThingWrite INVALID_DELETE_THING =
-                new ThingWrite(20, "The thing '%s' cannot be deleted, as the provided type '%s' is not a valid type or supertype.");
+                new ThingWrite(20, "The thing '%s' cannot be deleted, as the provided variable representing type(s) '%s' is not a valid type or supertype.");
         public static final ThingWrite INVALID_DELETE_THING_DIRECT =
-                new ThingWrite(21, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
+                new ThingWrite(21, "The thing '%s' cannot be deleted, as the provided direct variable representing type(s) '%s' is not valid.");
         public static final ThingWrite INVALID_DELETE_HAS =
                 new ThingWrite(22, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
         public static final ThingWrite ILLEGAL_IS_CONSTRAINT =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -276,7 +276,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
         public static final Pattern UNSATISFIABLE_PATTERN =
-                new Pattern(16, "The pattern '%s' can never be satisfied the current schema, specifically due to '%s'.");
+                new Pattern(16, "The pattern '%s' can never be satisfied the current schema, due to '%s'.");
+        public static final Pattern UNSATISFIABLE_SUB_PATTERN =
+                new Pattern(17, "The pattern '%s' can never be satisfied the current schema.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";
@@ -348,7 +350,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final ThingWrite THING_ISA_MISSING =
                 new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
         public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_INSERT =
-                new ThingWrite(16, "Illegal type variable '%s' found in insert query. Types can only be referred to by their labels in insert queries or then clauses.");
+                new ThingWrite(16, "The type variable '%s' must represent exactly one possible insertable type, rather than '%s'.");
         public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =
                 new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -278,9 +278,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern UNSATISFIABLE_PATTERN =
                 new Pattern(16, "The pattern '%s' can never be satisfied the current schema.");
         public static final Pattern UNSATISFIABLE_SUB_PATTERN =
-                new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to '$s'.");
+                new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to '%s'.");
         public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE =
-                new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to contradicting types for '$s'.");
+                new Pattern(18, "The pattern '%s' can never be satisfied the current schema, due to contradicting types for '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";
@@ -351,10 +351,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(14, "Attempted to re-insert pre-existing thing of matched variable '%s' as a new instance (isa) of type '%s'.");
         public static final ThingWrite THING_ISA_MISSING =
                 new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
-        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_INSERT =
-                new ThingWrite(16, "The type variable '%s' must represent exactly one possible insertable type, rather than '%s'.");
-        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =
-                new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
+        public static final ThingWrite AMBIGUOUS_TYPE_VARIABLE_IN_INSERT =
+                new ThingWrite(16, "Ambiguous type variable '%s' in insert could be any of the types '%s'. Insert variables must represent exactly 1 type.");
+//        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =  // TODO
+//                new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =
                 new ThingWrite(18, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -276,9 +276,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
         public static final Pattern UNSATISFIABLE_PATTERN =
-                new Pattern(16, "The pattern '%s' can never be satisfied the current schema, due to '%s'.");
+                new Pattern(16, "The pattern '%s' can never be satisfied the current schema.");
         public static final Pattern UNSATISFIABLE_SUB_PATTERN =
-                new Pattern(17, "The pattern '%s' can never be satisfied the current schema.");
+                new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to '$s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -249,8 +249,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(1, "The class '%s' cannot be casted to '%s'.");
         public static final Pattern ANONYMOUS_CONCEPT_VARIABLE =
                 new Pattern(2, "Attempted to refer to a concept using an anonymous variable. Their intended use is for inserting things.");
-        public static final Pattern ANONYMOUS_TYPE_VARIABLE =
-                new Pattern(3, "Attempted to refer to a type using an anonymous variable. Their intended use is for inserting things.");
+        public static final Pattern ANONYMOUS_TYPE_VARIABLE_CONSTRAINT =
+                new Pattern(3, "Query may not constrain an anonymous type variable");
         public static final Pattern UNBOUNDED_CONCEPT_VARIABLE =
                 new Pattern(4, "Invalid query containing unbounded concept variable '%s'.");
         public static final Pattern UNBOUNDED_NEGATION =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -279,6 +279,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(16, "The pattern '%s' can never be satisfied the current schema.");
         public static final Pattern UNSATISFIABLE_SUB_PATTERN =
                 new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to '$s'.");
+        public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE =
+                new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to contradicting types for '$s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "8e9b6af7048622bd3fe5a3fafbc589fd0fef6c3f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "446aead0851281c320477c22556838480f6cbc6f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "be735b6d3e3d4311261c1a9af29e1f92cb616694", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "8e9b6af7048622bd3fe5a3fafbc589fd0fef6c3f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "1e10a75c77efc2b5702a78bde5307ba9176888d9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "79c1c81433c479b8a747d03ab0588c85a9e0ad0c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "b2b457c700f5a537784c82acbe3553be04301acd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "ec77f76efc5ac7d2e0dc828f08b35630d3a5bde4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():
@@ -46,10 +46,14 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+#        commit = "0a91ae5feb657e31368f93efa37a2f6560119e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "0a91ae5feb657e31368f93efa37a2f6560119e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -27,8 +27,8 @@ def vaticle_dependencies():
 def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
-        remote = "https://github.com/vaticle/typeql-lang-java",
-        tag = "2.6.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        remote = "https://github.com/flyingsilverfin/typeql-lang-java",
+        commit = "be735b6d3e3d4311261c1a9af29e1f92cb616694", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,15 +46,15 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-#        commit = "0a91ae5feb657e31368f93efa37a2f6560119e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "0a91ae5feb657e31368f93efa37a2f6560119e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
+#    native.local_repository(
+#        name = "vaticle_typedb_behaviour",
+#        path = "../typedb-behaviour",
+#    )
 
 def vaticle_factory_tracing():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "446aead0851281c320477c22556838480f6cbc6f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "1e10a75c77efc2b5702a78bde5307ba9176888d9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "1ca29fde9ef185f995aac9f8baaffe6a42792168", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "0a91ae5feb657e31368f93efa37a2f6560119e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/flyingsilverfin/typeql-lang-java",
-        commit = "79c1c81433c479b8a747d03ab0588c85a9e0ad0c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "b2b457c700f5a537784c82acbe3553be04301acd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -129,7 +129,7 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
                         ASC,
                         comparableEdge -> comparableEdge.edge().from(),
                         vertex -> ComparableEdge.Thing.byInIID(
-                                new ThingEdgeImpl.Target(encoding, owner, vertex, optimisedType)
+                                new ThingEdgeImpl.Target(encoding, vertex, owner, optimisedType)
                         )
                 );
             }
@@ -152,7 +152,7 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
                             ASC,
                             comparableEdge -> KeyValue.of(comparableEdge.edge().from(), comparableEdge.edge().optimised().get()),
                             relationAndRole -> ComparableEdge.Thing.byInIID(
-                                    new ThingEdgeImpl.Target(encoding, owner, relationAndRole.key(), optimisedType)
+                                    new ThingEdgeImpl.Target(encoding, relationAndRole.key(), owner, optimisedType)
                             )
                     );
                 }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -464,8 +464,8 @@ public class Rule {
                 ids.add(relation.owner().id());
                 relation.players().forEach(rp -> {
                     ids.add(rp.player().id());
-                    if (rp.roleType().isPresent() && rp.roleType().get().id().isRetrievable()) {
-                        ids.add(rp.roleType().get().id().asRetrievable());
+                    if (rp.roleType().id().isRetrievable()) {
+                        ids.add(rp.roleType().id().asRetrievable());
                     }
                 });
                 if (isa.type().id().isRetrievable()) ids.add(isa.type().id().asRetrievable());
@@ -486,7 +486,7 @@ public class Rule {
                         thenConcepts.put(relationTypeIdentifier, relationType);
                         thenConcepts.put(isa().owner().id(), rel);
                         relation().players().forEach(rp -> {
-                            thenConcepts.putIfAbsent(rp.roleType().get().id(), getRole(rp, relationType, whenConcepts));
+                            thenConcepts.putIfAbsent(rp.roleType().id(), getRole(rp, relationType, whenConcepts));
                             thenConcepts.putIfAbsent(rp.player().id(), whenConcepts.get(rp.player().id()));
                         });
                         return thenConcepts;
@@ -505,7 +505,7 @@ public class Rule {
                     RoleType role = getRole(rp, relationType, whenConcepts);
                     Thing player = whenConcepts.get(rp.player().id()).asThing();
                     relation.addPlayer(role, player, true);
-                    thenConcepts.putIfAbsent(rp.roleType().get().id(), role);
+                    thenConcepts.putIfAbsent(rp.roleType().id(), role);
                     thenConcepts.putIfAbsent(rp.player().id(), player);
                 });
                 return Iterators.single(thenConcepts);
@@ -565,8 +565,7 @@ public class Rule {
                 RelationTraversal traversal = new RelationTraversal(relationId, set(relationType.getLabel())); // TODO include inheritance
                 relation().players().forEach(rp -> {
                     Identifier.Variable.Retrievable playerId = rp.player().id();
-                    assert rp.roleType().isPresent() && rp.roleType().get().label().isPresent()
-                            && whenConcepts.contains(playerId);
+                    assert rp.roleType().label().isPresent() && whenConcepts.contains(playerId);
                     traversal.player(playerId, whenConcepts.get(playerId).asThing().getIID(),
                             set(getRole(rp, relationType, whenConcepts).getLabel())); // TODO include inheritance
                 });
@@ -586,11 +585,11 @@ public class Rule {
             }
 
             private RoleType getRole(RelationConstraint.RolePlayer rp, RelationType scope, ConceptMap whenConcepts) {
-                if (rp.roleType().get().reference().isName()) {
-                    return whenConcepts.get(rp.roleType().get().reference().asName()).asRoleType();
+                if (rp.roleType().id().isName()) {
+                    return whenConcepts.get(rp.roleType().id().asName()).asRoleType();
                 } else {
-                    assert rp.roleType().get().reference().isLabel();
-                    return scope.getRelates(rp.roleType().get().label().get().properLabel().name());
+                    assert rp.roleType().id().isLabel();
+                    return scope.getRelates(rp.roleType().label().get().properLabel().name());
                 }
             }
         }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -180,7 +180,6 @@ public class Rule {
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_CANNOT_BE_SATISFIED, structure.label(), then);
     }
 
-
     /**
      * Remove type hints in the `then` pattern that are not valid in the `when` pattern
      */

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -170,14 +170,9 @@ public abstract class Concludable extends Resolvable<Conjunction> {
     * we could take information such as negated constraints into account.
      */
     boolean unificationSatisfiable(TypeVariable concludableTypeVar, TypeVariable conclusionTypeVar, ConceptManager conceptMgr) {
-
-        if (!concludableTypeVar.inferredTypes().isEmpty() && !conclusionTypeVar.inferredTypes().isEmpty()) {
-            return !Collections.disjoint(subtypeLabels(concludableTypeVar.inferredTypes(), conceptMgr).toSet(),
-                    conclusionTypeVar.inferredTypes());
-        } else {
-            // if either variable is allowed to be any type (ie empty set), its possible to do unification
-            return true;
-        }
+        assert !concludableTypeVar.inferredTypes().isEmpty() && !conclusionTypeVar.inferredTypes().isEmpty();
+        return !Collections.disjoint(subtypeLabels(concludableTypeVar.inferredTypes(), conceptMgr).toSet(),
+                conclusionTypeVar.inferredTypes());
     }
 
     /*
@@ -191,10 +186,8 @@ public abstract class Concludable extends Resolvable<Conjunction> {
     * take into account if an attribute owned is a key but the unification target requires a different value
      */
     boolean unificationSatisfiable(ThingVariable concludableThingVar, ThingVariable conclusionThingVar) {
-        boolean satisfiable = true;
-        if (!concludableThingVar.inferredTypes().isEmpty() && !conclusionThingVar.inferredTypes().isEmpty()) {
-            satisfiable = !Collections.disjoint(concludableThingVar.inferredTypes(), conclusionThingVar.inferredTypes());
-        }
+        assert !concludableThingVar.inferredTypes().isEmpty() && !conclusionThingVar.inferredTypes().isEmpty();
+        boolean satisfiable = !Collections.disjoint(concludableThingVar.inferredTypes(), conclusionThingVar.inferredTypes());
 
         if (!concludableThingVar.value().isEmpty() && !conclusionThingVar.value().isEmpty()) {
             // TODO: detect value contradictions between constant predicates

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -113,7 +113,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
         // This gives a deterministic ordering to the applicable rules, which is important for testing.
         return Iterators.iterate(applicableRules.keySet().stream().sorted(Comparator.comparing(Rule::getLabel))
-                                         .collect(Collectors.toList()));
+                .collect(Collectors.toList()));
     }
 
     abstract Map<Rule, Set<Unifier>> applicableRules(ConceptManager conceptMgr, LogicManager logicMgr);
@@ -124,13 +124,21 @@ public abstract class Concludable extends Resolvable<Conjunction> {
 
     public abstract AlphaEquivalence alphaEquals(Concludable that);
 
-    public boolean isRelation() { return false; }
+    public boolean isRelation() {
+        return false;
+    }
 
-    public boolean isHas() { return false; }
+    public boolean isHas() {
+        return false;
+    }
 
-    public boolean isIsa() { return false; }
+    public boolean isIsa() {
+        return false;
+    }
 
-    public boolean isAttribute() { return false; }
+    public boolean isAttribute() {
+        return false;
+    }
 
     public Relation asRelation() {
         throw TypeDBException.of(INVALID_CASTING, className(this.getClass()), className(Relation.class));
@@ -165,7 +173,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
 
         if (!concludableTypeVar.inferredTypes().isEmpty() && !conclusionTypeVar.inferredTypes().isEmpty()) {
             return !Collections.disjoint(subtypeLabels(concludableTypeVar.inferredTypes(), conceptMgr).toSet(),
-                                         conclusionTypeVar.inferredTypes());
+                    conclusionTypeVar.inferredTypes());
         } else {
             // if either variable is allowed to be any type (ie empty set), its possible to do unification
             return true;
@@ -308,7 +316,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                 clonedIsa = cloner.getClone(isa).asThing().asIsa();
             }
             return new Relation(cloner.conjunction(), cloner.getClone(relation).asThing().asRelation(), clonedIsa,
-                                iterate(labels).map(l -> cloner.getClone(l).asType().asLabel()).toSet());
+                    iterate(labels).map(l -> cloner.getClone(l).asType().asLabel()).toSet());
         }
 
         public RelationConstraint relation() {
@@ -382,25 +390,22 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                         clone.get(conjRP).add(thenRP);
                         return clone;
                     }).flatMap(newMapping -> matchRolePlayers(conjRolePLayers.subList(1, conjRolePLayers.size()),
-                                                              thenRolePlayers, newMapping, conceptMgr));
+                            thenRolePlayers, newMapping, conceptMgr));
         }
 
         private Unifier convertRPMappingToUnifier(Map<RolePlayer, Set<RolePlayer>> mapping,
                                                   Unifier.Builder unifierBuilder, ConceptManager conceptMgr) {
             mapping.forEach((conjRP, thenRPs) -> thenRPs.forEach(thenRP -> {
                 unifierBuilder.addThing(conjRP.player(), thenRP.player().id());
-                if (conjRP.roleType().isPresent()) {
-                    assert thenRP.roleType().isPresent();
-                    TypeVariable conjRoleType = conjRP.roleType().get();
-                    TypeVariable thenRoleType = thenRP.roleType().get();
-                    if (conjRoleType.id().isLabel()) {
-                        Set<Label> allowedTypes = iterate(conjRoleType.inferredTypes())
-                                .flatMap(roleLabel -> subtypeLabels(roleLabel, conceptMgr))
-                                .toSet();
-                        unifierBuilder.addLabelType(conjRoleType.id().asLabel(), allowedTypes, thenRoleType.id());
-                    } else {
-                        unifierBuilder.addVariableType(conjRoleType, thenRoleType.id());
-                    }
+                TypeVariable conjRoleType = conjRP.roleType();
+                TypeVariable thenRoleType = thenRP.roleType();
+                if (conjRoleType.id().isLabel()) {
+                    Set<Label> allowedTypes = iterate(conjRoleType.inferredTypes())
+                            .flatMap(roleLabel -> subtypeLabels(roleLabel, conceptMgr))
+                            .toSet();
+                    unifierBuilder.addLabelType(conjRoleType.id().asLabel(), allowedTypes, thenRoleType.id());
+                } else {
+                    unifierBuilder.addVariableType(conjRoleType, thenRoleType.id());
                 }
             }));
 
@@ -408,13 +413,8 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
 
         private boolean unificationSatisfiable(RolePlayer concludableRolePlayer, RolePlayer conclusionRolePlayer, ConceptManager conceptMgr) {
-            assert conclusionRolePlayer.roleType().isPresent();
-            boolean satisfiable = true;
-            if (concludableRolePlayer.roleType().isPresent()) {
-                satisfiable = unificationSatisfiable(concludableRolePlayer.roleType().get(), conclusionRolePlayer.roleType().get(), conceptMgr);
-            }
-            satisfiable &= unificationSatisfiable(concludableRolePlayer.player(), conclusionRolePlayer.player());
-            return satisfiable;
+            return unificationSatisfiable(concludableRolePlayer.roleType(), conclusionRolePlayer.roleType(), conceptMgr)
+                    && unificationSatisfiable(concludableRolePlayer.player(), conclusionRolePlayer.player());
         }
 
         @Override

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -46,6 +46,9 @@ import java.util.stream.Collectors;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REVERSE_UNIFICATION_MISSING_CONCEPT;
 
+/*
+TODO This class will now not have to deal with optionally not present role types. But they may be anonymous!
+ */
 public class Unifier {
 
     private final Map<Retrievable, Set<Variable>> unifier;
@@ -202,7 +205,7 @@ public class Unifier {
         }
 
         public void addVariableType(com.vaticle.typedb.core.pattern.variable.TypeVariable source, Variable target) {
-            assert source.id().isVariable();
+            assert source.id().isVariable(); // TODO this is no longer true
             unifier.computeIfAbsent(source.id().asRetrievable(), (s) -> new HashSet<>()).add(target);
             requirements.types(source.id(), source.inferredTypes());
             unifiedRequirements.types(target, source.inferredTypes());

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -205,7 +205,7 @@ public class Unifier {
         }
 
         public void addVariableType(com.vaticle.typedb.core.pattern.variable.TypeVariable source, Variable target) {
-            assert source.id().isVariable(); // TODO this is no longer true
+            assert source.id().isVariable();
             unifier.computeIfAbsent(source.id().asRetrievable(), (s) -> new HashSet<>()).add(target);
             requirements.types(source.id(), source.inferredTypes());
             unifiedRequirements.types(target, source.inferredTypes());

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -299,12 +299,11 @@ public class TypeInference {
         }
 
         private void restrict(Identifier.Variable id, FunctionalIterator<TypeVertex> types) {
-            Set<TypeVertex> ts = types.toSet();
             TraversalVertex.Properties.Type props = traversal.structure().typeVertex(id).props();
             Set<Label> existingLabels = props.labels();
-            if (existingLabels.isEmpty()) ts.iterator().forEachRemaining(t -> existingLabels.add(t.properLabel()));
+            if (existingLabels.isEmpty()) types.forEachRemaining(t -> existingLabels.add(t.properLabel()));
             else {
-                Set<Label> intersection = iterate(ts).filter(t -> existingLabels.contains(t.properLabel()))
+                Set<Label> intersection = types.filter(t -> existingLabels.contains(t.properLabel()))
                         .map(TypeVertex::properLabel).toSet();
                 props.clearLabels();
                 props.labels(intersection);

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -172,7 +172,7 @@ public class TypeInference {
 
     private Optional<Map<Identifier.Variable.Retrievable, Set<Label>>> executeTypeResolvers(TraversalBuilder traversalBuilder) {
         return logicCache.resolver().get(traversalBuilder.traversal().structure(), structure ->
-                traversalEng.combination(traversalBuilder.traversal(), thingVariableIds(traversalBuilder)).map(result -> {
+                traversalEng.combination(traversalBuilder.traversal(), retrievableThingIds(traversalBuilder)).map(result -> {
                             Map<Identifier.Variable.Retrievable, Set<Label>> mapping = new HashMap<>();
                             result.forEach((id, types) -> {
                                 Optional<Variable> originalVar = traversalBuilder.getOriginalVariable(id);
@@ -187,7 +187,7 @@ public class TypeInference {
         );
     }
 
-    private Set<Identifier.Variable.Retrievable> thingVariableIds(TraversalBuilder traversalBuilder) {
+    private Set<Identifier.Variable.Retrievable> retrievableThingIds(TraversalBuilder traversalBuilder) {
         return iterate(traversalBuilder.resolverToOriginal.values()).filter(Variable::isThing).map(var -> {
             assert var.id().isRetrievable();
             return var.id().asRetrievable();
@@ -259,9 +259,8 @@ public class TypeInference {
         private TypeVariable register(TypeVariable var) {
             if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
             TypeVariable resolver;
-            if (var.label().isPresent() && var.label().get().scope().isPresent()) {
+            if (var.id().isLabel() && var.label().get().scope().isPresent()) {
                 resolver = new TypeVariable(newSystemId());
-                traversal.labels(resolver.id(), var.inferredTypes());
             } else {
                 resolver = var;
             }
@@ -408,10 +407,6 @@ public class TypeInference {
                 traversal.equalTypes(resolver.id(), register(isaConstraint.type()).id());
             } else {
                 throw TypeDBException.of(ILLEGAL_STATE);
-            }
-            if (isaConstraint.type().label().isPresent()) {
-                restrict(resolver.id(), graphMgr.schema().getSubtypes(
-                        graphMgr.schema().getType(isaConstraint.type().label().get().properLabel())));
             }
         }
 

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -66,7 +66,7 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -420,7 +420,7 @@ public class TypeInference {
          */
         private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
             TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
-            if (type == null) throw TypeDBException.of(UNSATISFIABLE_PATTERN, conjunction, constraint);
+            if (type == null) throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
             restrict(resolver.id(), iterate(type));
         }
 
@@ -476,7 +476,7 @@ public class TypeInference {
                 });
                 resolverValueTypes.put(resolver.id(), valueTypes);
             } else if (!resolverValueTypes.get(resolver.id()).containsAll(valueTypes)) {
-                throw TypeDBException.of(UNSATISFIABLE_PATTERN, conjunction, constraint);
+                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
             }
             registerSubAttribute(resolver);
         }

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -441,12 +441,10 @@ public class TypeInference {
             for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
                 TypeVariable playerResolver = register(rolePlayer.player());
                 TypeVariable actingRoleResolver = new TypeVariable(newSystemId());
-                if (rolePlayer.roleType().isPresent()) {
-                    TypeVariable roleTypeResolver = register(rolePlayer.roleType().get());
-                    traversal.sub(actingRoleResolver.id(), roleTypeResolver.id(), true);
-                    restrict(roleTypeResolver.id(), graphMgr.schema().roleTypes());
-                    restrict(actingRoleResolver.id(), graphMgr.schema().roleTypes());
-                }
+                TypeVariable roleTypeResolver = register(rolePlayer.roleType());
+                traversal.sub(actingRoleResolver.id(), roleTypeResolver.id(), true);
+                restrict(roleTypeResolver.id(), graphMgr.schema().roleTypes());
+                restrict(actingRoleResolver.id(), graphMgr.schema().roleTypes());
                 traversal.relates(resolver.id(), actingRoleResolver.id());
                 traversal.plays(playerResolver.id(), actingRoleResolver.id());
                 restrict(playerResolver.id(), graphMgr.schema().playerTypes());
@@ -457,8 +455,7 @@ public class TypeInference {
         private void registerInsertableRelation(TypeVariable resolver, RelationConstraint constraint) {
             for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
                 TypeVariable playerResolver = register(rolePlayer.player());
-                TypeVariable roleResolver = register(rolePlayer.roleType().isPresent() ?
-                        rolePlayer.roleType().get() : new TypeVariable(newSystemId()));
+                TypeVariable roleResolver = register(rolePlayer.roleType());
                 traversal.relates(resolver.id(), roleResolver.id());
                 traversal.plays(playerResolver.id(), roleResolver.id());
             }

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN_VARIABLE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
@@ -301,6 +302,10 @@ public class TypeInference {
                 props.clearLabels();
                 props.labels(intersection);
             }
+            if (props.labels().isEmpty()) {
+                conjunction.setCoherent(false);
+                throw TypeDBException.of(UNSATISFIABLE_PATTERN_VARIABLE, conjunction, id);
+            }
         }
 
         private void registerOwns(TypeVariable resolver, OwnsConstraint ownsConstraint) {
@@ -420,7 +425,10 @@ public class TypeInference {
          */
         private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
             TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
-            if (type == null) throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
+            if (type == null) {
+                conjunction.setCoherent(false);
+                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
+            }
             restrict(resolver.id(), iterate(type));
         }
 
@@ -476,6 +484,7 @@ public class TypeInference {
                 });
                 resolverValueTypes.put(resolver.id(), valueTypes);
             } else if (!resolverValueTypes.get(resolver.id()).containsAll(valueTypes)) {
+                conjunction.setCoherent(false);
                 throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
             }
             registerSubAttribute(resolver);

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -196,7 +196,7 @@ public class Conjunction implements Pattern, Cloneable {
     @Override
     public Conjunction clone() {
         return new Conjunction(VariableCloner.cloneFromConjunction(this).variables(),
-                               iterate(this.negations).map(Negation::clone).toList());
+                iterate(this.negations).map(Negation::clone).toList());
     }
 
     @Override
@@ -209,8 +209,8 @@ public class Conjunction implements Pattern, Cloneable {
                         .collect(Collectors.joining("" + SEMICOLON + SPACE)))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.joining("; " + NEW_LINE,
-                                            "" + CURLY_OPEN + SPACE,
-                                            "" + SEMICOLON + SPACE + negationsToString + CURLY_CLOSE));
+                        "" + CURLY_OPEN + SPACE,
+                        "" + SEMICOLON + SPACE + negationsToString + CURLY_CLOSE));
 
     }
 

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -157,7 +157,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         private final int hash;
 
         public RolePlayer(TypeVariable roleType, ThingVariable player, int repetition) {
-            assert roleType.reference().isName() ||
+            assert roleType.id().isName() || roleType.id().isAnonymous() ||
                     (roleType.label().isPresent() && roleType.label().get().scope().isPresent());
             if (player == null) throw new NullPointerException("Null player");
             this.roleType = roleType;

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -95,6 +95,8 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
                 traversal.playing(player.id(), role);
                 traversal.isa(role, roleType.id());
             } else {
+                // TODO we should not add the role type variable if it is anonymous, not even separately. This may involve
+                // TODO flipping conjunctions to own constraints instead of variables
                 assert !roleType.inferredTypes().isEmpty();
                 traversal.rolePlayer(owner.id(), player.id(), roleType.inferredTypes(), rep);
             }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -95,7 +95,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
                 traversal.playing(player.id(), role);
                 traversal.isa(role, roleType.id());
             } else {
-                assert roleType.reference().isLabel() && !roleType.inferredTypes().isEmpty();
+                assert !roleType.inferredTypes().isEmpty();
                 traversal.rolePlayer(owner.id(), player.id(), roleType.inferredTypes(), rep);
             }
         }

--- a/pattern/constraint/type/TypeConstraint.java
+++ b/pattern/constraint/type/TypeConstraint.java
@@ -30,7 +30,9 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ANONYMOUS_TYPE_VARIABLE_CONSTRAINT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public abstract class TypeConstraint extends Constraint {
 
@@ -41,6 +43,9 @@ public abstract class TypeConstraint extends Constraint {
         if (owner == null) throw new NullPointerException("Null owner");
         this.owner = owner;
         variables = Collections.unmodifiableSet(set(additionalVariables, set(owner)));
+        if (iterate(variables).anyMatch(var -> var.id().isAnonymous())) {
+            throw TypeDBException.of(ANONYMOUS_TYPE_VARIABLE_CONSTRAINT);
+        }
     }
 
     public static TypeConstraint of(TypeVariable owner, com.vaticle.typeql.lang.pattern.constraint.TypeConstraint constraint,

--- a/pattern/constraint/type/TypeConstraint.java
+++ b/pattern/constraint/type/TypeConstraint.java
@@ -30,9 +30,7 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ANONYMOUS_TYPE_VARIABLE_CONSTRAINT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public abstract class TypeConstraint extends Constraint {
 
@@ -43,9 +41,6 @@ public abstract class TypeConstraint extends Constraint {
         if (owner == null) throw new NullPointerException("Null owner");
         this.owner = owner;
         variables = Collections.unmodifiableSet(set(additionalVariables, set(owner)));
-        if (iterate(variables).anyMatch(var -> var.id().isAnonymous())) {
-            throw TypeDBException.of(ANONYMOUS_TYPE_VARIABLE_CONSTRAINT);
-        }
     }
 
     public static TypeConstraint of(TypeVariable owner, com.vaticle.typeql.lang.pattern.constraint.TypeConstraint constraint,

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -106,7 +106,8 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         // TODO: create vertex properties first, then the vertex itself, then edges
         //       that way, we can make properties to be 'final' objects that are
         //       included in equality and hashCode of vertices
-        if (!inferredTypes().isEmpty()) traversal.types(id(), inferredTypes());
+        assert !inferredTypes().isEmpty();
+        traversal.types(id(), inferredTypes());
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -249,6 +249,14 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         // TODO: create vertex properties first, then the vertex itself, then edges
         //       that way, we can make properties to be 'final' objects that are
         //       included in equality and hashCode of vertices
+
+        // TODO: this is a hack, see `RelationConstraint.addTo()`. We should not be adding all variables before constraints
+        // TODO: the best solution for this is to add constraints, which add their own variables. In the meantime we exclude anonymous type vars
+        if (id().isAnonymous()) {
+            assert constraints().isEmpty();
+            return;
+        }
+
         if (!inferredTypes().isEmpty()) traversal.labels(id(), inferredTypes());
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -50,6 +50,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULT
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_REGEX;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_SUB;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_VALUE_TYPE;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariable> {
 
@@ -253,7 +254,7 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         // TODO: this is a hack, see `RelationConstraint.addTo()`. We should not be adding all variables before constraints
         // TODO: the best solution for this is to add constraints, which add their own variables. In the meantime we exclude anonymous type vars
         // TODO: this needs to be done so we don't over-generate all variations of answers with different anonymous type variables when we don't need to
-        if (id().isAnonymous()) {
+        if (id().isAnonymous() && iterate(constraining()).filter(c -> c.isThing() && c.asThing().isRelation()).count() == 1) {
             assert constraints().isEmpty();
             return;
         }

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -252,6 +252,7 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
 
         // TODO: this is a hack, see `RelationConstraint.addTo()`. We should not be adding all variables before constraints
         // TODO: the best solution for this is to add constraints, which add their own variables. In the meantime we exclude anonymous type vars
+        // TODO: this needs to be done so we don't over-generate all variations of answers with different anonymous type variables when we don't need to
         if (id().isAnonymous()) {
             assert constraints().isEmpty();
             return;

--- a/pattern/variable/VariableRegistry.java
+++ b/pattern/variable/VariableRegistry.java
@@ -74,11 +74,11 @@ public class VariableRegistry {
         }
     }
 
-    public static VariableRegistry createFromThings(List<com.vaticle.typeql.lang.pattern.variable.ThingVariable<?>> variables) {
+    public static VariableRegistry createFromThings(List<? extends BoundVariable> variables) {
         return createFromThings(variables, true);
     }
 
-    public static VariableRegistry createFromThings(List<com.vaticle.typeql.lang.pattern.variable.ThingVariable<?>> variables, boolean allowDerived) {
+    public static VariableRegistry createFromThings(List<? extends BoundVariable> variables, boolean allowDerived) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "things")) {
             return createFromVariables(variables, null, allowDerived);
         }

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -161,7 +161,7 @@ public class Deleter {
                 if (var.relation().isPresent()) {
                     var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = matched.get(rolePlayer.player().reference().asName()).asThing();
-                        RoleType roleType = getRoleType(relation, player, rolePlayer);
+                        RoleType roleType = getRoleType(relation, rolePlayer);
                         relation.removePlayer(roleType, player);
                     });
                 } else {

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -54,7 +54,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.I
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INVALID_DELETE_THING_DIRECT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_IID_NOT_INSERTABLE;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.EXHAUSTIVE;
-import static com.vaticle.typedb.core.query.common.Util.getRoleType;
+import static com.vaticle.typedb.core.query.common.Util.getExplicitRoleType;
 
 public class Deleter {
 
@@ -161,7 +161,7 @@ public class Deleter {
                 if (var.relation().isPresent()) {
                     var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = matched.get(rolePlayer.player().reference().asName()).asThing();
-                        RoleType roleType = getRoleType(relation, rolePlayer);
+                        RoleType roleType = getExplicitRoleType(relation, player, rolePlayer);
                         relation.removePlayer(roleType, player);
                     });
                 } else {

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -180,13 +180,14 @@ public class Deleter {
                 Thing thing = detached.get(var);
                 ThingType type = thing.getType();
                 if (var.isa().isPresent() && !thing.isDeleted()) {
-                    Label typeLabel = var.isa().get().type().label().get().properLabel();
+                    Set<Label> typeLabels = var.isa().get().type().inferredTypes();
                     if (var.isa().get().isExplicit()) {
-                        if (type.getLabel().equals(typeLabel)) thing.delete();
-                        else throw TypeDBException.of(INVALID_DELETE_THING_DIRECT, var.reference(), typeLabel);
+                        if (typeLabels.size() == 1 && type.getLabel().equals(typeLabels.iterator().next())) {
+                            thing.delete();
+                        } else throw TypeDBException.of(INVALID_DELETE_THING_DIRECT, var.reference(), typeLabels);
                     } else {
-                        if (type.getSupertypes().anyMatch(t -> t.getLabel().equals(typeLabel))) thing.delete();
-                        else throw TypeDBException.of(INVALID_DELETE_THING, var.reference(), typeLabel);
+                        if (type.getSupertypes().anyMatch(t -> typeLabels.contains(t.getLabel()))) thing.delete();
+                        else throw TypeDBException.of(INVALID_DELETE_THING, var.reference(), typeLabels);
                     }
                 }
             }

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -277,7 +277,7 @@ public class Inserter {
                 if (var.relation().isPresent()) {
                     var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = insert(rolePlayer.player());
-                        RoleType roleType = getRoleType(relation, player, rolePlayer);
+                        RoleType roleType = getRoleType(relation, rolePlayer);
                         relation.addPlayer(roleType, player);
                     });
                 } else { // var.relation().size() > 1

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -73,7 +73,7 @@ import static com.vaticle.typedb.core.concurrent.executor.Executors.async1;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.async;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.produce;
 import static com.vaticle.typedb.core.query.QueryManager.PARALLELISATION_SPLIT_MIN;
-import static com.vaticle.typedb.core.query.common.Util.getRoleType;
+import static com.vaticle.typedb.core.query.common.Util.getExplicitRoleType;
 
 public class Inserter {
 
@@ -277,7 +277,7 @@ public class Inserter {
                 if (var.relation().isPresent()) {
                     var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = insert(rolePlayer.player());
-                        RoleType roleType = getRoleType(relation, rolePlayer);
+                        RoleType roleType = getExplicitRoleType(relation, player, rolePlayer);
                         relation.addPlayer(roleType, player);
                     });
                 } else { // var.relation().size() > 1

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -123,7 +123,7 @@ public class QueryManager {
         if (context.sessionType().isSchema()) throw conceptMgr.exception(SESSION_SCHEMA_VIOLATION);
         if (context.transactionType().isRead()) throw conceptMgr.exception(TRANSACTION_DATA_READ_VIOLATION);
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert")) {
-            return Inserter.create(reasoner, conceptMgr, query, context).execute().onError(conceptMgr::exception);
+            return Inserter.create(reasoner, logicMgr, conceptMgr, query, context).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
@@ -137,7 +137,7 @@ public class QueryManager {
         if (context.sessionType().isSchema()) throw conceptMgr.exception(SESSION_SCHEMA_VIOLATION);
         if (context.transactionType().isRead()) throw conceptMgr.exception(TRANSACTION_DATA_READ_VIOLATION);
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "delete")) {
-            Deleter.create(reasoner, query, context).execute();
+            Deleter.create(reasoner, logicMgr, query, context).execute();
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
@@ -151,7 +151,7 @@ public class QueryManager {
         if (context.sessionType().isSchema()) throw conceptMgr.exception(SESSION_SCHEMA_VIOLATION);
         if (context.transactionType().isRead()) throw conceptMgr.exception(TRANSACTION_DATA_READ_VIOLATION);
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "update")) {
-            return Updater.create(reasoner, conceptMgr, query, context).execute().onError(conceptMgr::exception);
+            return Updater.create(reasoner, logicMgr, conceptMgr, query, context).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -28,11 +28,7 @@ import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.pattern.constraint.thing.RelationConstraint;
 import com.vaticle.typedb.core.pattern.variable.TypeVariable;
 
-import java.util.Set;
-
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_AMBIGUOUS;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_MISSING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 
 public class Util {
@@ -42,22 +38,22 @@ public class Util {
     public static RoleType getRoleType(Relation relation, Thing player, RelationConstraint.RolePlayer rolePlayer) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_role_type")) {
             RoleType roleType;
-            Set<? extends RoleType> inferred;
-            if (rolePlayer.roleType().isPresent()) {
-                RelationType relationType = relation.getType();
-                TypeVariable var = rolePlayer.roleType().get();
-                if ((roleType = relationType.getRelates(var.label().get().label())) == null) {
-                    throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
-                }
-            } else if ((inferred = player.getType().getPlays()
-                    .filter(rt -> rt.getRelationType().equals(relation.getType()))
-                    .toSet()).size() == 1) {
-                roleType = inferred.iterator().next();
-            } else if (inferred.size() > 1) {
-                throw TypeDBException.of(ROLE_TYPE_AMBIGUOUS, rolePlayer.player().reference());
-            } else {
-                throw TypeDBException.of(ROLE_TYPE_MISSING, rolePlayer.player().reference());
+//            Set<? extends RoleType> inferred;
+//            if (rolePlayer.roleType().isPresent()) {
+            RelationType relationType = relation.getType();
+            TypeVariable var = rolePlayer.roleType();
+            if ((roleType = relationType.getRelates(var.label().get().label())) == null) {
+                throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
             }
+//            } else if ((inferred = player.getType().getPlays()
+//                    .filter(rt -> rt.getRelationType().equals(relation.getType()))
+//                    .toSet()).size() == 1) {
+//                roleType = inferred.iterator().next();
+//            } else if (inferred.size() > 1) {
+//                throw TypeDBException.of(ROLE_TYPE_AMBIGUOUS, rolePlayer.player().reference());
+//            } else {
+//                throw TypeDBException.of(ROLE_TYPE_MISSING, rolePlayer.player().reference());
+//            }
             return roleType;
         }
     }

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -22,37 +22,43 @@ import com.vaticle.factory.tracing.client.FactoryTracingThreadStatic;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concept.thing.Relation;
+import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.type.RelationType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.pattern.constraint.thing.RelationConstraint;
 import com.vaticle.typedb.core.pattern.variable.TypeVariable;
 
+import java.util.Set;
+
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_AMBIGUOUS;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_MISSING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 
 public class Util {
 
     private static final String TRACE_PREFIX = "util.";
 
-    public static RoleType getRoleType(Relation relation, RelationConstraint.RolePlayer rolePlayer) {
+    public static RoleType getExplicitRoleType(Relation relation, Thing player, RelationConstraint.RolePlayer rolePlayer) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_role_type")) {
             RoleType roleType;
-//            Set<? extends RoleType> inferred;
-//            if (rolePlayer.roleType().isPresent()) {
-            RelationType relationType = relation.getType();
-            TypeVariable var = rolePlayer.roleType();
-            if ((roleType = relationType.getRelates(var.label().get().label())) == null) {
-                throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
+            Set<? extends RoleType> inferred;
+            if (rolePlayer.roleType().id().isLabel()) {
+                RelationType relationType = relation.getType();
+                TypeVariable var = rolePlayer.roleType();
+                assert var.label().isPresent();
+                if ((roleType = relationType.getRelates(var.label().get().label())) == null) {
+                    throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
+                }
+            } else if ((inferred = player.getType().getPlays()
+                    .filter(rt -> rt.getRelationType().equals(relation.getType()))
+                    .toSet()).size() == 1) {
+                roleType = inferred.iterator().next();
+            } else if (inferred.size() > 1) {
+                throw TypeDBException.of(ROLE_TYPE_AMBIGUOUS, rolePlayer.player().reference());
+            } else {
+                throw TypeDBException.of(ROLE_TYPE_MISSING, rolePlayer.player().reference());
             }
-//            } else if ((inferred = player.getType().getPlays()
-//                    .filter(rt -> rt.getRelationType().equals(relation.getType()))
-//                    .toSet()).size() == 1) {
-//                roleType = inferred.iterator().next();
-//            } else if (inferred.size() > 1) {
-//                throw TypeDBException.of(ROLE_TYPE_AMBIGUOUS, rolePlayer.player().reference());
-//            } else {
-//                throw TypeDBException.of(ROLE_TYPE_MISSING, rolePlayer.player().reference());
-//            }
             return roleType;
         }
     }

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -22,7 +22,6 @@ import com.vaticle.factory.tracing.client.FactoryTracingThreadStatic;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concept.thing.Relation;
-import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.type.RelationType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.pattern.constraint.thing.RelationConstraint;
@@ -35,7 +34,7 @@ public class Util {
 
     private static final String TRACE_PREFIX = "util.";
 
-    public static RoleType getRoleType(Relation relation, Thing player, RelationConstraint.RolePlayer rolePlayer) {
+    public static RoleType getRoleType(Relation relation, RelationConstraint.RolePlayer rolePlayer) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_role_type")) {
             RoleType roleType;
 //            Set<? extends RoleType> inferred;

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.EXHAUSTIVE;
 import static com.vaticle.typedb.core.concurrent.executor.Executors.PARALLELISATION_FACTOR;
@@ -117,7 +118,11 @@ public class Reasoner {
         logicMgr.typeInference().infer(disjunction);
         if (!disjunction.isCoherent()) {
             Set<Conjunction> causes = incoherentConjunctions(disjunction);
-            throw TypeDBException.of(UNSATISFIABLE_PATTERN, disjunction, causes);
+            if (set(disjunction.conjunctions()).equals(causes)) {
+                throw TypeDBException.of(UNSATISFIABLE_PATTERN, disjunction);
+            } else {
+                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, disjunction, causes);
+            }
         }
     }
 

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -129,7 +129,7 @@ public class ResolverRegistry {
     }
 
     public ResolverView.FilteredNegation negated(Negated negated, Conjunction upstream) {
-        LOG.debug("Creating Negation resolver for : {}", negated);
+        LOG.trace("Creating Negation resolver for : {}", negated);
         Actor.Driver<NegationResolver> negatedResolver = Actor.driver(driver -> new NegationResolver(
                 driver, negated, this, traversalEngine, conceptMgr, resolutionTracing
         ), executorService);
@@ -147,7 +147,7 @@ public class ResolverRegistry {
     }
 
     public Actor.Driver<ConditionResolver> registerCondition(Rule.Condition ruleCondition) {
-        LOG.debug("Register retrieval for rule condition actor: '{}'", ruleCondition);
+        LOG.trace("Register retrieval for rule condition actor: '{}'", ruleCondition);
         Actor.Driver<ConditionResolver> resolver = ruleConditions.computeIfAbsent(ruleCondition.rule(), (r) -> Actor.driver(
                 driver -> new ConditionResolver(driver, ruleCondition, this, traversalEngine,
                                                 conceptMgr, logicMgr, resolutionTracing), executorService
@@ -159,7 +159,7 @@ public class ResolverRegistry {
     }
 
     public Actor.Driver<ConclusionResolver> registerConclusion(Rule.Conclusion conclusion) {
-        LOG.debug("Register retrieval for rule conclusion actor: '{}'", conclusion);
+        LOG.trace("Register retrieval for rule conclusion actor: '{}'", conclusion);
         Actor.Driver<ConclusionResolver> resolver = ruleConclusions.computeIfAbsent(conclusion.rule(), r -> Actor.driver(
                 driver -> new ConclusionResolver(driver, conclusion, this,
                                                  traversalEngine, conceptMgr, resolutionTracing), executorService
@@ -179,7 +179,7 @@ public class ResolverRegistry {
     }
 
     private ResolverView.FilteredRetrievable registerRetrievable(com.vaticle.typedb.core.logic.resolvable.Retrievable retrievable) {
-        LOG.debug("Register RetrievableResolver: '{}'", retrievable.pattern());
+        LOG.trace("Register RetrievableResolver: '{}'", retrievable.pattern());
         Actor.Driver<RetrievableResolver> resolver = Actor.driver(driver -> new RetrievableResolver(
                 driver, retrievable, this, traversalEngine, conceptMgr, resolutionTracing
         ), executorService);
@@ -190,7 +190,7 @@ public class ResolverRegistry {
 
     // note: must be thread safe. We could move to a ConcurrentHashMap if we create an alpha-equivalence wrapper
     private synchronized ResolverView.MappedConcludable registerConcludable(Concludable concludable) {
-        LOG.debug("Register ConcludableResolver: '{}'", concludable.pattern());
+        LOG.trace("Register ConcludableResolver: '{}'", concludable.pattern());
         for (Map.Entry<Concludable, Actor.Driver<ConcludableResolver>> c : concludableResolvers.entrySet()) {
             // TODO: This needs to be optimised from a linear search to use an alpha hash
             AlphaEquivalence alphaEquality = concludable.alphaEquals(c.getKey());
@@ -209,7 +209,7 @@ public class ResolverRegistry {
     }
 
     public Actor.Driver<ConjunctionResolver.Nested> nested(Conjunction conjunction) {
-        LOG.debug("Creating Conjunction resolver for : {}", conjunction);
+        LOG.trace("Creating Conjunction resolver for : {}", conjunction);
         Actor.Driver<ConjunctionResolver.Nested> resolver = Actor.driver(driver -> new ConjunctionResolver.Nested(
                 driver, conjunction, this, traversalEngine, conceptMgr, logicMgr, resolutionTracing
         ), executorService);
@@ -219,7 +219,7 @@ public class ResolverRegistry {
     }
 
     public Actor.Driver<DisjunctionResolver.Nested> nested(Disjunction disjunction) {
-        LOG.debug("Creating Disjunction resolver for : {}", disjunction);
+        LOG.trace("Creating Disjunction resolver for : {}", disjunction);
         Actor.Driver<DisjunctionResolver.Nested> resolver = Actor.driver(driver -> new DisjunctionResolver.Nested(
                 driver, disjunction, this, traversalEngine, conceptMgr, resolutionTracing
         ), executorService);

--- a/reasoner/resolution/answer/AnswerStateImpl.java
+++ b/reasoner/resolution/answer/AnswerStateImpl.java
@@ -137,9 +137,7 @@ public abstract class AnswerStateImpl implements AnswerState {
 
                 @Override
                 public FinishedImpl finish(ConceptMap conceptMap) {
-                    ConceptMap answer = conceptMap;
-                    if (!explainable()) answer = conceptMap.filter(filter());
-                    return FinishedImpl.create(filter(), answer, root(), explainable());
+                    return FinishedImpl.create(filter(), conceptMap, root(), explainable());
                 }
 
             }

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -189,7 +189,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
     @Override
     protected void initialiseDownstreamResolvers() {
-        LOG.debug("{}: initialising downstream resolvers", name());
+        LOG.trace("{}: initialising downstream resolvers", name());
         concludable.getApplicableRules(conceptMgr, logicMgr).forEachRemaining(rule -> concludable.getUnifiers(rule)
                 .forEachRemaining(unifier -> {
                     if (isTerminated()) return;
@@ -241,7 +241,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
     }
 
     protected CachingRequestState<?, ConceptMap> createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating new Responses for iteration{}, request: {}", name(), iteration, fromUpstream);
+        LOG.trace("{}: Creating new Responses for iteration{}, request: {}", name(), iteration, fromUpstream);
         Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
         cacheRegistersByRoot.putIfAbsent(root, new HashMap<>());
         Map<ConceptMap, AnswerCache<?, ConceptMap>> cacheRegister = cacheRegistersByRoot.get(root);

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -124,7 +124,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
 
     @Override
     protected void initialiseDownstreamResolvers() {
-        LOG.debug("{}: initialising downstream resolvers", name());
+        LOG.trace("{}: initialising downstream resolvers", name());
         try {
             ruleResolver = registry.registerCondition(conclusion.rule().condition());
             isInitialised = true;
@@ -161,7 +161,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
     }
 
     private ConclusionRequestState<?> createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new ConclusionResponse for request: {}", name(), fromUpstream);
+        LOG.trace("{}: Creating a new ConclusionResponse for request: {}", name(), fromUpstream);
 
         ConclusionRequestState<?> requestState;
         if (fromUpstream.partialAnswer().asConclusion().isExplain()) {

--- a/reasoner/resolution/resolver/ConjunctionResolver.java
+++ b/reasoner/resolution/resolver/ConjunctionResolver.java
@@ -144,7 +144,7 @@ public abstract class ConjunctionResolver<RESOLVER extends ConjunctionResolver<R
 
     @Override
     protected void initialiseDownstreamResolvers() {
-        LOG.debug("{}: initialising downstream resolvers", name());
+        LOG.trace("{}: initialising downstream resolvers", name());
         Set<Concludable> concludables = concludablesTriggeringRules();
         Set<Retrievable> retrievables = Retrievable.extractFrom(conjunction(), concludables);
         resolvables.addAll(concludables);
@@ -170,7 +170,7 @@ public abstract class ConjunctionResolver<RESOLVER extends ConjunctionResolver<R
 
     @Override
     protected RequestState requestStateCreate(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new RequestState for request: {}", name(), fromUpstream);
+        LOG.trace("{}: Creating a new RequestState for request: {}", name(), fromUpstream);
         Plans.Plan plan = plans.create(fromUpstream, resolvables, negateds);
         assert !plan.isEmpty() && fromUpstream.partialAnswer().isCompound();
         RequestState requestState = requestStateNew(iteration);
@@ -182,7 +182,7 @@ public abstract class ConjunctionResolver<RESOLVER extends ConjunctionResolver<R
     protected RequestState requestStateReiterate(Request fromUpstream, RequestState requestStatePrior,
                                                   int newIteration) {
         assert newIteration > requestStatePrior.iteration();
-        LOG.debug("{}: Updating RequestState for iteration '{}'", name(), newIteration);
+        LOG.trace("{}: Updating RequestState for iteration '{}'", name(), newIteration);
         Plans.Plan plan = plans.create(fromUpstream, resolvables, negateds);
         assert !plan.isEmpty() && fromUpstream.partialAnswer().isCompound();
         RequestState requestStateNextIteration = requestStateForIteration(requestStatePrior, newIteration);

--- a/reasoner/resolution/resolver/DisjunctionResolver.java
+++ b/reasoner/resolution/resolver/DisjunctionResolver.java
@@ -73,7 +73,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
 
     @Override
     protected void initialiseDownstreamResolvers() {
-        LOG.debug("{}: initialising downstream resolvers", name());
+        LOG.trace("{}: initialising downstream resolvers", name());
         for (com.vaticle.typedb.core.pattern.Conjunction conjunction : disjunction.conjunctions()) {
             try {
                 downstreamResolvers.put(registry.nested(conjunction), conjunction);
@@ -87,7 +87,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
 
     @Override
     protected RequestState requestStateCreate(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new RequestState for request: {}", name(), fromUpstream);
+        LOG.trace("{}: Creating a new RequestState for request: {}", name(), fromUpstream);
         assert fromUpstream.partialAnswer().isCompound();
         RequestState requestState = new RequestState(iteration);
         for (Driver<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers.keySet()) {
@@ -102,7 +102,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
     @Override
     protected RequestState requestStateReiterate(Request fromUpstream, RequestState requestStatePrior,
                                                   int newIteration) {
-        LOG.debug("{}: Updating RequestState for iteration '{}'", name(), newIteration);
+        LOG.trace("{}: Updating RequestState for iteration '{}'", name(), newIteration);
 
         assert newIteration > requestStatePrior.iteration() && fromUpstream.partialAnswer().isCompound();
 

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -82,7 +82,7 @@ public class NegationResolver extends Resolver<NegationResolver> {
 
     @Override
     protected void initialiseDownstreamResolvers() {
-        LOG.debug("{}: initialising downstream resolvers", name());
+        LOG.trace("{}: initialising downstream resolvers", name());
 
         Disjunction disjunction = negated.pattern();
         if (disjunction.conjunctions().size() == 1) {

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -118,7 +118,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     }
 
     protected RetrievableRequestState createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new RequestState for iteration:{}, request: {}", name(), iteration, fromUpstream);
+        LOG.trace("{}: Creating a new RequestState for iteration:{}, request: {}", name(), iteration, fromUpstream);
         assert fromUpstream.partialAnswer().isRetrievable();
         Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
         cacheRegistersByRoot.putIfAbsent(root, new HashMap<>());

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -86,13 +86,13 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         public void submitAnswer(Finished answer) {
-            LOG.debug("Submitting answer: {}", answer);
+            LOG.trace("Submitting answer: {}", answer);
             onAnswer.accept(answer);
         }
 
         @Override
         public void submitFail(int iteration) {
-            LOG.debug("Submitting fail in iteration: {}", iteration);
+            LOG.trace("Submitting fail in iteration: {}", iteration);
             onFail.accept(iteration);
         }
 
@@ -192,7 +192,7 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         public void submitAnswer(Finished answer) {
-            LOG.debug("Submitting answer: {}", answer);
+            LOG.trace("Submitting answer: {}", answer);
             onAnswer.accept(answer);
         }
 
@@ -278,7 +278,7 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         public void submitAnswer(Top.Explain.Finished answer) {
-            LOG.debug("Submitting answer: {}", answer);
+            LOG.trace("Submitting answer: {}", answer);
             onAnswer.accept(answer);
         }
 

--- a/test/behaviour/debug/debug.feature
+++ b/test/behaviour/debug/debug.feature
@@ -17,10 +17,86 @@
 
 Feature: Debugging Space
 
-  Background:
+  Background: Open connection and create a simple extensible schema
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
+    Given connection create database: typedb
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
 
-  # Paste any scenarios below for debugging.
-  # Do not commit any changes to this file.
+    Given typeql define
+      """
+      define
+      person sub entity,
+        plays friendship:friend,
+        plays employment:employee,
+        owns name,
+        owns age,
+        owns ref @key;
+      company sub entity,
+        plays employment:employer,
+        owns name,
+        owns ref @key;
+      friendship sub relation,
+        relates friend,
+        owns ref @key;
+      employment sub relation,
+        relates employee,
+        relates employer,
+        owns ref @key;
+      name sub attribute, value string;
+      age sub attribute, value long;
+      ref sub attribute, value long;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+
+  Scenario: when multiple relation instances exist with the same roleplayer, matching that player returns just 1 answer
+    Given typeql define
+      """
+      define
+      residency sub relation,
+        relates resident,
+        owns ref @key;
+      person plays residency:resident;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $x isa person, has ref 0;
+      $e (employee: $x) isa employment, has ref 1;
+      $f (friend: $x) isa friendship, has ref 2;
+      $r (resident: $x) isa residency, has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    Given get answers of typeql match
+      """
+      match $r isa relation;
+      """
+    Given uniquely identify answer concepts
+      | r         |
+      | key:ref:1 |
+      | key:ref:2 |
+      | key:ref:3 |
+    When get answers of typeql match
+      """
+      match ($x) isa relation;
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | key:ref:0 |
+#    When get answers of typeql match
+#      """
+#      match ($x);
+#      """
+#    Then uniquely identify answer concepts
+#      | x         |
+#      | key:ref:0 |

--- a/test/behaviour/reasoner/verification/Materialiser.java
+++ b/test/behaviour/reasoner/verification/Materialiser.java
@@ -131,7 +131,8 @@ public class Materialiser {
                     .materialise(conditionAns, tx.traversal(), tx.concepts())
                     .map(conclusionAns -> new ConceptMap(filterRetrievable(conclusionAns)))
                     .filter(thenConcludable::isInferredAnswer)
-                    .forEachRemaining(ans -> record(conditionAns, ans)));
+                    .forEachRemaining(ans -> record(conditionAns, ans))
+            );
             return requiresReiteration;
         }
 

--- a/test/behaviour/reasoner/verification/SoundnessVerifier.java
+++ b/test/behaviour/reasoner/verification/SoundnessVerifier.java
@@ -92,11 +92,11 @@ class SoundnessVerifier {
             });
         } else {
             throw new SoundnessException(String.format("Soundness testing found an answer within an explanation that " +
-                                                               "should not be present for rule \"%s\"" +
-                                                               ".\nAnswer:\n%s\nIncorrectly derived from " +
-                                                               "condition:\n%s",
-                                                       explanation.rule().getLabel(), explanation.conclusionAnswer(),
-                                                       explanation.conditionAnswer()));
+                            "should not be present for rule \"%s\"" +
+                            ".\nAnswer:\n%s\nIncorrectly derived from " +
+                            "condition:\n%s",
+                    explanation.rule().getLabel(), explanation.conclusionAnswer(),
+                    explanation.conditionAnswer()));
         }
     }
 

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -198,14 +198,14 @@ public class TypeQLSteps {
     @Then("answer size is: {number}")
     public void answer_quantity_assertion(int expectedAnswers) {
         assertEquals(String.format("Expected [%d] answers, but got [%d]", expectedAnswers, answers.size()),
-                     expectedAnswers, answers.size());
+                expectedAnswers, answers.size());
     }
 
     @Then("uniquely identify answer concepts")
     public void uniquely_identify_answer_concepts(List<Map<String, String>> answerConcepts) {
         assertEquals(
                 String.format("The number of identifier entries (rows) should match the number of answers, but found %d identifier entries and %d answers.",
-                              answerConcepts.size(), answers.size()),
+                        answerConcepts.size(), answers.size()),
                 answerConcepts.size(), answers.size()
         );
 
@@ -220,7 +220,7 @@ public class TypeQLSteps {
             }
             assertEquals(
                     String.format("An identifier entry (row) should match 1-to-1 to an answer, but there were %d matching identifier entries for answer with variables %s.",
-                                  matchingIdentifiers.size(), answer.concepts().keySet().toString()),
+                            matchingIdentifiers.size(), answer.concepts().keySet().toString()),
                     1, matchingIdentifiers.size()
             );
         }
@@ -230,7 +230,7 @@ public class TypeQLSteps {
     public void order_of_answer_concepts_is(List<Map<String, String>> answersIdentifiers) {
         assertEquals(
                 String.format("The number of identifier entries (rows) should match the number of answers, but found %d identifier entries and %d answers.",
-                              answersIdentifiers.size(), answers.size()),
+                        answersIdentifiers.size(), answers.size()),
                 answersIdentifiers.size(), answers.size()
         );
         for (int i = 0; i < answers.size(); i++) {
@@ -247,7 +247,7 @@ public class TypeQLSteps {
     public void aggregate_value_is(double expectedAnswer) {
         assertNotNull("The last executed query was not an aggregate query", numericAnswer);
         assertEquals(String.format("Expected answer to equal %f, but it was %f.", expectedAnswer, numericAnswer.asNumber().doubleValue()),
-                     expectedAnswer, numericAnswer.asNumber().doubleValue(), 0.001);
+                expectedAnswer, numericAnswer.asNumber().doubleValue(), 0.001);
     }
 
     @Then("aggregate answer is not a number")
@@ -265,8 +265,8 @@ public class TypeQLSteps {
                 .collect(Collectors.toSet());
 
         assertEquals(String.format("Expected [%d] answer groups, but found [%d].",
-                                   answerIdentifierGroups.size(), answerGroups.size()),
-                     answerIdentifierGroups.size(), answerGroups.size()
+                answerIdentifierGroups.size(), answerGroups.size()),
+                answerIdentifierGroups.size(), answerGroups.size()
         );
 
         for (AnswerIdentifierGroup answerIdentifierGroup : answerIdentifierGroups) {
@@ -303,7 +303,7 @@ public class TypeQLSteps {
                 }
                 assertEquals(
                         String.format("An identifier entry (row) should match 1-to-1 to an answer, but there were [%d] matching identifier entries for answer with variables %s.",
-                                      matchingIdentifiers.size(), answer.concepts().keySet().toString()),
+                                matchingIdentifiers.size(), answer.concepts().keySet().toString()),
                         1, matchingIdentifiers.size()
                 );
             }
@@ -320,7 +320,7 @@ public class TypeQLSteps {
         }
 
         assertEquals(String.format("Expected [%d] answer groups, but found [%d].", expectations.size(), numericAnswerGroups.size()),
-                     expectations.size(), numericAnswerGroups.size()
+                expectations.size(), numericAnswerGroups.size()
         );
 
         for (Map.Entry<String, Double> expectation : expectations.entrySet()) {
@@ -349,7 +349,7 @@ public class TypeQLSteps {
             double actualAnswer = answerGroup.numeric().asNumber().doubleValue();
             assertEquals(
                     String.format("Expected answer [%f] for group [%s], but got [%f]",
-                                  expectedAnswer, expectation.getKey(), actualAnswer),
+                            expectedAnswer, expectation.getKey(), actualAnswer),
                     expectedAnswer, actualAnswer, 0.001
             );
         }
@@ -371,8 +371,8 @@ public class TypeQLSteps {
             answersIdentifiers = new ArrayList<>();
             for (Map<String, String> rawAnswerIdentifiers : answerIdentifierTable) {
                 answersIdentifiers.add(rawAnswerIdentifiers.entrySet().stream()
-                                               .filter(e -> !e.getKey().equals(GROUP_COLUMN_NAME))
-                                               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                        .filter(e -> !e.getKey().equals(GROUP_COLUMN_NAME))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             }
         }
     }
@@ -501,6 +501,18 @@ public class TypeQLSteps {
             TypeQLMatch typeQLQuery = TypeQL.parseQuery(query).asMatch();
             long answerSize = tx().query().match(typeQLQuery).toList().size();
             assertEquals(1, answerSize);
+        }
+    }
+
+    @Then("templated typeql match; throw exception")
+    public void get_answers_of_templated_typeql_match_throws_exception(String templatedTypeQLQuery) {
+        String templatedQuery = String.join("\n", templatedTypeQLQuery);
+        for (ConceptMap answer : answers) {
+            String queryString = applyQueryTemplate(templatedQuery, answer);
+            assertThrows(() -> {
+                TypeQLMatch query = TypeQL.parseQuery(queryString).asMatch();
+                tx().query().match(query).toList();
+            });
         }
     }
 
@@ -639,7 +651,9 @@ public class TypeQLSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (!concept.isThing()) { return false; }
+            if (!concept.isThing()) {
+                return false;
+            }
 
             Set<? extends Attribute> keys = concept.asThing().getHas(true).toSet();
 

--- a/test/integration/QueryTest.java
+++ b/test/integration/QueryTest.java
@@ -293,18 +293,25 @@ public class QueryTest {
                 }
 
                 try (TypeDB.Transaction transaction = session.transaction(Arguments.Transaction.Type.WRITE)) {
-                    String deleteString = "match $x isa thing; delete $x isa thing;";
-                    TypeQLDelete deleteQuery = TypeQL.parseQuery(deleteString);
-                    transaction.query().delete(deleteQuery);
-                    transaction.commit();
+                    String match = "match $r ($x) isa relation;";
+                    TypeQLMatch deleteQuery = TypeQL.parseQuery(match).asMatch();
+                    List<ConceptMap> answers = transaction.query().match(deleteQuery).toList();
+                    System.out.println(answers.size());
                 }
-
-                try (TypeDB.Transaction transaction = session.transaction(Arguments.Transaction.Type.READ)) {
-                    String matchString = "match $x isa thing;";
-                    TypeQLMatch matchQuery = TypeQL.parseQuery(matchString);
-                    FunctionalIterator<ConceptMap> answers = transaction.query().match(matchQuery);
-                    assertFalse(answers.hasNext());
-                }
+//
+//                try (TypeDB.Transaction transaction = session.transaction(Arguments.Transaction.Type.WRITE)) {
+//                    String deleteString = "match $x isa thing; delete $x isa thing;";
+//                    TypeQLDelete deleteQuery = TypeQL.parseQuery(deleteString);
+//                    transaction.query().delete(deleteQuery);
+//                    transaction.commit();
+//                }
+//
+//                try (TypeDB.Transaction transaction = session.transaction(Arguments.Transaction.Type.READ)) {
+//                    String matchString = "match $x isa thing;";
+//                    TypeQLMatch matchQuery = TypeQL.parseQuery(matchString);
+//                    FunctionalIterator<ConceptMap> answers = transaction.query().match(matchQuery);
+//                    assertFalse(answers.hasNext());
+//                }
             }
         }
     }

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.collection.Bytes.MB;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Session.Type.DATA;
-import static com.vaticle.typedb.core.common.parameters.Arguments.Session.Type.SCHEMA;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Transaction.Type.WRITE;
 import static com.vaticle.typedb.core.common.test.Util.assertThrows;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -707,7 +706,7 @@ public class TypeInferenceTest {
     }
 
     @Test
-    public void all_things_is_empty_set() throws IOException {
+    public void all_things() throws IOException {
         define_standard_schema("basic-schema");
         TypeInference typeInference = transaction.logic().typeInference();
 

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -370,9 +370,9 @@ public class TypeInferenceTest {
     @Test
     public void value_comparision_between_double_long() throws IOException {
         define_custom_schema("define" +
-                                     " house-number sub attribute, value long;" +
-                                     " length sub attribute, value double;" +
-                                     " name sub attribute, value string;"
+                " house-number sub attribute, value long;" +
+                " length sub attribute, value double;" +
+                " name sub attribute, value string;"
         );
 
         TypeInference typeInference = transaction.logic().typeInference();
@@ -452,25 +452,25 @@ public class TypeInferenceTest {
     @Test
     public void relation_staggered_role_hierarchy() {
         define_custom_schema("define" +
-                                     " person sub entity," +
-                                     "  plays partnership:partner," +
-                                     "  plays marriage:spouse;" +
-                                     "" +
-                                     " man sub person," +
-                                     "  plays hetero-marriage:husband;" +
-                                     "" +
-                                     " woman sub person," +
-                                     "   plays hetero-marriage:wife;" +
-                                     "" +
-                                     " partnership sub relation," +
-                                     "  relates partner;" +
-                                     "" +
-                                     " marriage sub partnership," +
-                                     "  relates spouse as partner;" +
-                                     "" +
-                                     " hetero-marriage sub marriage," +
-                                     "  relates husband as spouse," +
-                                     "  relates wife as spouse;");
+                " person sub entity," +
+                "  plays partnership:partner," +
+                "  plays marriage:spouse;" +
+                "" +
+                " man sub person," +
+                "  plays hetero-marriage:husband;" +
+                "" +
+                " woman sub person," +
+                "   plays hetero-marriage:wife;" +
+                "" +
+                " partnership sub relation," +
+                "  relates partner;" +
+                "" +
+                " marriage sub partnership," +
+                "  relates spouse as partner;" +
+                "" +
+                " hetero-marriage sub marriage," +
+                "  relates husband as spouse," +
+                "  relates wife as spouse;");
         TypeInference typeInference = transaction.logic().typeInference();
 
         String queryString = "match $r (spouse: $yoko, $role: $john) isa $m; $john isa man;";
@@ -522,6 +522,7 @@ public class TypeInferenceTest {
         Map<String, Set<String>> expected = new HashMap<>() {{
             put("$yoko", set("man", "woman", "person"));
             put("$_0", set("marriage"));
+            put("$_1", set("marriage:husband", "marriage:spouse", "marriage:wife"));
             put("$_marriage", set("marriage"));
         }};
 
@@ -543,6 +544,7 @@ public class TypeInferenceTest {
             put("$john", set("man"));
             put("$role", set("marriage:husband", "marriage:wife", "marriage:spouse", "relation:role"));
             put("$r", set("marriage"));
+            put("$_0", set("marriage:husband", "marriage:spouse", "marriage:wife"));
             put("$a", set("person", "man", "woman"));
             put("$_marriage:husband", set("marriage:husband"));
             put("$_marriage", set("marriage"));
@@ -690,8 +692,8 @@ public class TypeInferenceTest {
     @Test
     public void has_with_minimal_cycle() {
         define_custom_schema("define " +
-                                     "unit sub attribute, value string, owns unit, owns ref;" +
-                                     "ref sub attribute, value long;");
+                "unit sub attribute, value string, owns unit, owns ref;" +
+                "ref sub attribute, value long;");
         TypeInference typeInference = transaction.logic().typeInference();
         String queryString = "match" +
                 "  $a has $a;";
@@ -717,7 +719,7 @@ public class TypeInferenceTest {
 
         Map<String, Set<String>> expected = new HashMap<>() {{
             put("$x", set("animal", "mammal", "reptile", "tortoise", "person", "man", "woman", "dog", "name", "email",
-                          "marriage", "triangle", "right-angled-triangle", "square", "perimeter", "area", "hypotenuse-length", "label"));
+                    "marriage", "triangle", "right-angled-triangle", "square", "perimeter", "area", "hypotenuse-length", "label"));
             put("$_thing", set("thing"));
         }};
 
@@ -870,11 +872,11 @@ public class TypeInferenceTest {
     @Test
     public void overridden_relates_are_valid() {
         define_custom_schema("define" +
-                                     " marriage sub relation, relates spouse;" +
-                                     " hetero-marriage sub marriage," +
-                                     "   relates husband as spouse, relates wife as spouse;" +
-                                     " person sub entity, plays marriage:spouse, plays hetero-marriage:husband," +
-                                     "   plays hetero-marriage:wife;"
+                " marriage sub relation, relates spouse;" +
+                " hetero-marriage sub marriage," +
+                "   relates husband as spouse, relates wife as spouse;" +
+                " person sub entity, plays marriage:spouse, plays hetero-marriage:husband," +
+                "   plays hetero-marriage:wife;"
         );
         TypeInference typeInference = transaction.logic().typeInference();
         String queryString = "match $m (spouse: $x, spouse: $y) isa marriage;";
@@ -1051,8 +1053,8 @@ public class TypeInferenceTest {
     @Test
     public void infer_key_attributes() {
         define_custom_schema("define" +
-                                     " person sub entity, owns name @key;" +
-                                     " name sub attribute, value string;"
+                " person sub entity, owns name @key;" +
+                " name sub attribute, value string;"
         );
 
         TypeInference typeInference = transaction.logic().typeInference();
@@ -1073,9 +1075,9 @@ public class TypeInferenceTest {
     @Test
     public void role_labels_reduced_by_full_type_resolver() {
         define_custom_schema("define" +
-                                     " person sub entity, plays partnership:partner;" +
-                                     " partnership sub relation, relates partner;" +
-                                     " business sub relation, relates partner;"
+                " person sub entity, plays partnership:partner;" +
+                " partnership sub relation, relates partner;" +
+                " business sub relation, relates partner;"
         );
 
         TypeInference typeInference = transaction.logic().typeInference();
@@ -1125,10 +1127,10 @@ public class TypeInferenceTest {
     @Test
     public void cannot_insert_abstract_attributes() {
         define_custom_schema("define " +
-                                     " person sub entity, owns name;" +
-                                     " woman sub person, owns maiden-name as name;" +
-                                     " name sub attribute, value string, abstract;" +
-                                     " maiden-name sub name, value string;");
+                " person sub entity, owns name;" +
+                " woman sub person, owns maiden-name as name;" +
+                " name sub attribute, value string, abstract;" +
+                " maiden-name sub name, value string;");
         String queryString = "match $x isa woman, has name 'smith';";
         Disjunction disjunction = createDisjunction(queryString);
         transaction.logic().typeInference().infer(disjunction);
@@ -1142,9 +1144,9 @@ public class TypeInferenceTest {
     @Test
     public void cannot_insert_if_relation_type_too_general() {
         define_custom_schema("define" +
-                                     " person sub entity, plays marriage:husband, plays marriage:wife;" +
-                                     " partnership sub relation, relates partner;" +
-                                     " marriage sub partnership, relates husband as partner, relates wife as partner;");
+                " person sub entity, plays marriage:husband, plays marriage:wife;" +
+                " partnership sub relation, relates partner;" +
+                " marriage sub partnership, relates husband as partner, relates wife as partner;");
         String queryString = "match $x isa person; (wife: $x) isa partnership;";
         Disjunction disjunction = createDisjunction(queryString);
         transaction.logic().typeInference().infer(disjunction);
@@ -1158,9 +1160,9 @@ public class TypeInferenceTest {
     @Test
     public void cannot_insert_if_role_is_too_general() {
         define_custom_schema("define" +
-                                     " person sub entity, plays marriage:husband, plays marriage:wife;" +
-                                     " partnership sub relation, relates partner;" +
-                                     " marriage sub partnership, relates husband as partner, relates wife as partner;");
+                " person sub entity, plays marriage:husband, plays marriage:wife;" +
+                " partnership sub relation, relates partner;" +
+                " marriage sub partnership, relates husband as partner, relates wife as partner;");
         String queryString = "match $x isa person; (partner: $x) isa marriage;";
         Disjunction disjunction = createDisjunction(queryString);
         transaction.logic().typeInference().infer(disjunction);
@@ -1174,22 +1176,21 @@ public class TypeInferenceTest {
     @Test
     public void variable_relations_allowed_only_if_all_possibilities_are_insertable() {
         define_custom_schema("define" +
-                                     " person sub entity, plays marriage:husband, plays marriage:wife;" +
-                                     " partnership sub relation, relates partner;" +
-                                     " marriage sub partnership, relates husband as partner, relates wife as partner;");
+                " person sub entity, plays marriage:husband, plays marriage:wife;" +
+                " partnership sub relation, relates partner;" +
+                " marriage sub partnership, relates husband as partner, relates wife as partner;");
         transaction.logic().putRule(
                 "marriage-rule",
                 TypeQL.parsePattern("{$x isa person; $t isa marriage;}").asConjunction(),
                 TypeQL.parseVariable("(wife: $x) isa $t").asThing());
     }
 
-
     @Test
     public void nested_negation_outer_scope_correctly_reduces_resolved_types() {
         define_custom_schema("define " +
-                                     "person sub entity, plays marriage:spouse;" +
-                                     "woman sub person;" +
-                                     "marriage sub relation, relates spouse;");
+                "person sub entity, plays marriage:spouse;" +
+                "woman sub person;" +
+                "marriage sub relation, relates spouse;");
 
         String minimallyRestricted = "match $x isa person; not { ($x) isa marriage; };";
         Disjunction disjunction = createDisjunction(minimallyRestricted);
@@ -1197,6 +1198,7 @@ public class TypeInferenceTest {
         HashMap<String, Set<String>> expected = new HashMap<>() {{
             put("$x", set("person", "woman"));
             put("$_0", set("marriage"));
+            put("$_1", set("marriage:spouse"));
             put("$_marriage", set("marriage"));
         }};
         // test the inner negation
@@ -1208,12 +1210,12 @@ public class TypeInferenceTest {
         expected = new HashMap<>() {{
             put("$x", set("woman"));
             put("$_0", set("marriage"));
+            put("$_1", set("marriage:spouse"));
             put("$_marriage", set("marriage"));
         }};
         // test the inner negation
         assertEquals(expected, resolvedTypeMap(restrictedDisjunction.conjunctions().get(0).negations().iterator().next().disjunction().conjunctions().get(0)));
     }
-
 
     /**
      * If the type resolver conflates anonymous or generated variables between the inner or outer nestings,
@@ -1222,23 +1224,23 @@ public class TypeInferenceTest {
     @Test
     public void nested_negation_is_satisfiable() {
         define_custom_schema("define session sub entity,\n" +
-                                     "          plays reported-fault:parent-session,\n" +
-                                     "          plays unanswered-question:parent-session;\n" +
-                                     "      fault sub entity,\n" +
-                                     "          plays reported-fault:relevant-fault,\n" +
-                                     "          plays fault-identification:identified-fault;\n" +
-                                     "      question sub entity,\n" +
-                                     "          plays fault-identification:identifying-question,\n" +
-                                     "          plays unanswered-question:question-not-answered;\n" +
-                                     "      reported-fault sub relation,\n" +
-                                     "          relates relevant-fault,\n" +
-                                     "          relates parent-session;\n" +
-                                     "      unanswered-question sub relation,\n" +
-                                     "          relates question-not-answered,\n" +
-                                     "          relates parent-session;\n" +
-                                     "      fault-identification sub relation,\n" +
-                                     "          relates identifying-question,\n" +
-                                     "          relates identified-fault;\n"
+                "          plays reported-fault:parent-session,\n" +
+                "          plays unanswered-question:parent-session;\n" +
+                "      fault sub entity,\n" +
+                "          plays reported-fault:relevant-fault,\n" +
+                "          plays fault-identification:identified-fault;\n" +
+                "      question sub entity,\n" +
+                "          plays fault-identification:identifying-question,\n" +
+                "          plays unanswered-question:question-not-answered;\n" +
+                "      reported-fault sub relation,\n" +
+                "          relates relevant-fault,\n" +
+                "          relates parent-session;\n" +
+                "      unanswered-question sub relation,\n" +
+                "          relates question-not-answered,\n" +
+                "          relates parent-session;\n" +
+                "      fault-identification sub relation,\n" +
+                "          relates identifying-question,\n" +
+                "          relates identified-fault;\n"
         );
         String query = "match (relevant-fault: $flt, parent-session: $ts) isa reported-fault;\n" +
                 "          not {\n" +
@@ -1248,5 +1250,47 @@ public class TypeInferenceTest {
         Disjunction disjunction = createDisjunction(query);
         transaction.logic().typeInference().infer(disjunction);
         assertTrue(disjunction.conjunctions().get(0).negations().iterator().next().disjunction().conjunctions().get(0).isCoherent());
+    }
+
+    @Test
+    public void variable_types_are_inferred() {
+        define_custom_schema("define " +
+                "person sub entity," +
+                "    owns first-name," +
+                "    owns last-name," +
+                "    owns age," +
+                "    plays employment:employee;" +
+                "company sub entity," +
+                "    plays employment:employer;" +
+                "employment sub relation," +
+                "    relates employee," +
+                "    relates employer;" +
+                "name sub attribute, value string, abstract;" +
+                "first-name sub name;" +
+                "last-name sub name;" +
+                "age sub attribute, value long;");
+
+
+        String query = "match $x isa $rel-type; $rel-type relates $role-type; $role-type type employment:employee;";
+        Disjunction disjunction = createDisjunction(query);
+        transaction.logic().typeInference().infer(disjunction);
+
+        HashMap<String, Set<String>> expected = new HashMap<>() {{
+            put("$x", set("employment"));
+            put("$rel-type", set("employment"));
+            put("$role-type", set("employment:employee"));
+        }};
+        assertEquals(expected, resolvedTypeMap(disjunction.conjunctions().get(0)));
+
+        query = "match $x isa $t; $t plays $role-type; $role-type type employment:employee;";
+        disjunction = createDisjunction(query);
+        transaction.logic().typeInference().infer(disjunction);
+
+        expected = new HashMap<>() {{
+            put("$x", set("person"));
+            put("$t", set("person"));
+            put("$role-type", set("employment:employee"));
+        }};
+        assertEquals(expected, resolvedTypeMap(disjunction.conjunctions().get(0)));
     }
 }

--- a/test/integration/reasoner/ExplanationTest.java
+++ b/test/integration/reasoner/ExplanationTest.java
@@ -488,10 +488,10 @@ public class ExplanationTest {
         }
     }
 
-    private List<Explanation> assertSingleExplainableExplanations(ConceptMap ans, int anonymousConcepts, int explainablesCount,
+    private List<Explanation> assertSingleExplainableExplanations(ConceptMap ans, int anonymousThings, int explainablesCount,
                                                                   int explanationsCount, RocksTransaction txn) {
         List<ConceptMap.Explainable> explainables = ans.explainables().iterator().toList();
-        assertEquals(anonymousConcepts, iterate(ans.concepts().keySet()).filter(Identifier::isAnonymous).count());
+        assertEquals(anonymousThings, iterate(ans.concepts().keySet()).filter(id -> id.isAnonymous() && ans.get(id).isThing()).count());
         assertEquals(explainablesCount, explainables.size());
         ConceptMap.Explainable explainable = explainables.iterator().next();
         assertNotEquals(NOT_IDENTIFIED, explainable.id());

--- a/test/integration/reasoner/ExplanationTest.java
+++ b/test/integration/reasoner/ExplanationTest.java
@@ -196,6 +196,13 @@ public class ExplanationTest {
         }
     }
 
+    /**
+     * TODO: this test exposes the fact that a variable type (eg. `match $r isa $relation;`) that unifies with a label type,
+     * will not have a valid mapping in the Explanation. However, we decide this is actually consistent,
+     * since the conclusion answer does not return an answer for that labelled type (eg. from `then { (friend: $x) isa friendship; }`)
+     * Ie. the mapping takes variables/answers from the query to variables and answers in the conclusion,
+     * but there is no answer in the conclusion for the variable.
+     */
     @Test
     public void test_relation_explainable_variable_type() {
         try (RocksSession session = typedb.session(database, Arguments.Session.Type.SCHEMA)) {

--- a/traversal/GraphTraversal.java
+++ b/traversal/GraphTraversal.java
@@ -146,6 +146,12 @@ public abstract class GraphTraversal extends Traversal {
         structure.typeVertex(attributeType).props().valueType(Encoding.ValueType.of(valueType));
     }
 
+    public void valueType(Identifier.Variable attributeType, Set<TypeQLArg.ValueType> valueTypes) {
+        valueTypes.forEach(valueType ->
+                structure.typeVertex(attributeType).props().valueType(Encoding.ValueType.of(valueType))
+        );
+    }
+
     public static class Type extends GraphTraversal {
 
         public Type() {

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -333,7 +333,7 @@ public class GraphPlanner implements Planner {
     private void optimise(GraphManager graph, boolean singleUse) {
         updateObjective(graph);
         if (isUpToDate() && isOptimal()) {
-            if (LOG.isDebugEnabled()) LOG.trace("GraphPlanner still optimal and up-to-date");
+            if (LOG.isTraceEnabled()) LOG.trace("GraphPlanner still optimal and up-to-date");
             return;
         }
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -333,7 +333,7 @@ public class GraphPlanner implements Planner {
     private void optimise(GraphManager graph, boolean singleUse) {
         updateObjective(graph);
         if (isUpToDate() && isOptimal()) {
-            if (LOG.isDebugEnabled()) LOG.debug("GraphPlanner still optimal and up-to-date");
+            if (LOG.isDebugEnabled()) LOG.trace("GraphPlanner still optimal and up-to-date");
             return;
         }
 
@@ -355,7 +355,7 @@ public class GraphPlanner implements Planner {
 
         isUpToDate = true;
         totalDuration -= allocatedDuration - between(start, endSolver).toMillis();
-        printDebug(start, endSolver, end);
+        printTrace(start, endSolver, end);
     }
 
     private void throwPlanningError() {
@@ -365,12 +365,12 @@ public class GraphPlanner implements Planner {
         throw TypeDBException.of(UNEXPECTED_PLANNING_ERROR);
     }
 
-    private void printDebug(Instant start, Instant endSolver, Instant end) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Optimisation status         : {}", optimiser.status().name());
-            LOG.debug("Solver duration             : {} (ms)", between(start, endSolver).toMillis());
-            LOG.debug("Procedure creation duration : {} (ms)", between(endSolver, end).toMillis());
-            LOG.debug("Total duration ------------ : {} (ms)", between(start, end).toMillis());
+    private void printTrace(Instant start, Instant endSolver, Instant end) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Optimisation status         : {}", optimiser.status().name());
+            LOG.trace("Solver duration             : {} (ms)", between(start, endSolver).toMillis());
+            LOG.trace("Procedure creation duration : {} (ms)", between(endSolver, end).toMillis());
+            LOG.trace("Total duration ------------ : {} (ms)", between(start, end).toMillis());
         }
     }
 

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -178,8 +178,8 @@ public class GraphProcedure implements PermutationProcedure {
         assertWithinFilterBounds(filter);
         return async(startVertex().iterator(graphMgr, params).map(
                 // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-                v -> new GraphIterator(graphMgr, v, this, params, filter).distinct()
-        ), parallelisation);
+                v -> new GraphIterator(graphMgr, v, this, params, filter)
+        ), parallelisation).distinct();
     }
 
     @Override
@@ -192,8 +192,8 @@ public class GraphProcedure implements PermutationProcedure {
         assertWithinFilterBounds(filter);
         return startVertex().iterator(graphMgr, params).flatMap(
                 // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-                sv -> new GraphIterator(graphMgr, sv, this, params, filter).distinct()
-        );
+                sv -> new GraphIterator(graphMgr, sv, this, params, filter)
+        ).distinct();
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB queries now allow anonymous type variables, specifically enabled to allow the insertion of anonymous type variables for relations (eg `($person) isa friendship` will now be interpreted as `($_: $person) isa friendship`). This guarantees possible role types are always inferred and allows us to use sorted iterators when traversing relations in the new traversal engine.

## What are the changes implemented in this PR?

* Depend on a new TypeQL that allows anonymous type variables, and always inserts the anonymous role type variables when no role type is give at all
* Update `VariableRegistry` to handle anonymous thing and type variables
* propagate the assumption that a role type variable is always present in relations
* disallow constraints on anonymous type variables (only place holders)
