### PR TITLE
Simplify type inference

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -281,7 +281,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(17, "The pattern '%s' can never be satisfied the current schema, due to '%s'.");
         public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE =
                 new Pattern(18, "The pattern '%s' can never be satisfied the current schema, due to contradicting types for '%s'.");
-
+        public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE_VALUE =
+                new Pattern(19, "The pattern '%s' can never be satisfied the current schema, due to contradicting attribute value types for '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -20,8 +20,8 @@ package com.vaticle.typedb.core.logic;
 
 import com.vaticle.typedb.core.common.cache.CommonCache;
 import com.vaticle.typedb.core.common.parameters.Label;
+import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
-import com.vaticle.typedb.core.traversal.structure.Structure;
 
 import java.util.Map;
 import java.util.Optional;
@@ -29,20 +29,24 @@ import java.util.Set;
 
 public class LogicCache {
 
-    private final CommonCache<Structure, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeResolverCache;
+    private final CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeInferenceCache;
     private final CommonCache<String, Rule> ruleCache;
 
     public LogicCache() {
         this.ruleCache = new CommonCache<>();
-        this.typeResolverCache = new CommonCache<>();
+        this.typeInferenceCache = new CommonCache<>();
     }
 
     public LogicCache(int size, int timeOutMinutes) {
         this.ruleCache = new CommonCache<>(size, timeOutMinutes);
-        this.typeResolverCache = new CommonCache<>(size, timeOutMinutes);
+        this.typeInferenceCache = new CommonCache<>(size, timeOutMinutes);
     }
 
-    public CommonCache<Structure, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> resolver() { return typeResolverCache; }
+    public CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> inference() {
+        return typeInferenceCache;
+    }
 
-    CommonCache<String, Rule> rule() { return ruleCache; }
+    CommonCache<String, Rule> rule() {
+        return ruleCache;
+    }
 }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -402,13 +402,13 @@ public class Rule {
         }
 
         private void validateInsertable(LogicManager logicMgr) {
-//            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeInference().typePermutations(rule.when, false);
-//            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
-//
-//            whenCombinations.forEachRemaining(nameLabelMap -> {
-//                if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
-//                    throw TypeDBException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
-//            });
+            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenTypes = logicMgr.typeInference().typePermutations(rule.when, false);
+            Set<Map<Identifier.Variable.Name, Label>> allowedThenTypes = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
+
+            whenTypes.forEachRemaining(nameLabelMap -> {
+                if (allowedThenTypes.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
+                    throw TypeDBException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
+            });
         }
 
         public interface Isa {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -402,13 +402,13 @@ public class Rule {
         }
 
         private void validateInsertable(LogicManager logicMgr) {
-            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeInference().typePermutations(rule.when, false);
-            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
-
-            whenCombinations.forEachRemaining(nameLabelMap -> {
-                if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
-                    throw TypeDBException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
-            });
+//            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeInference().typePermutations(rule.when, false);
+//            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
+//
+//            whenCombinations.forEachRemaining(nameLabelMap -> {
+//                if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
+//                    throw TypeDBException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
+//            });
         }
 
         public interface Isa {

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -28,14 +28,12 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typedb.core.logic.LogicCache;
 import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.Disjunction;
-import com.vaticle.typedb.core.pattern.Negation;
 import com.vaticle.typedb.core.pattern.constraint.thing.HasConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.IIDConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.IsConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.IsaConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.RelationConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.ValueConstraint;
-import com.vaticle.typedb.core.pattern.constraint.type.LabelConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.OwnsConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.PlaysConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.RegexConstraint;
@@ -43,250 +41,204 @@ import com.vaticle.typedb.core.pattern.constraint.type.RelatesConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.SubConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.TypeConstraint;
 import com.vaticle.typedb.core.pattern.constraint.type.ValueTypeConstraint;
-import com.vaticle.typedb.core.pattern.variable.SystemReference;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
 import com.vaticle.typedb.core.pattern.variable.TypeVariable;
 import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.TraversalEngine;
 import com.vaticle.typedb.core.traversal.common.Identifier;
-import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Name;
+import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable;
 import com.vaticle.typedb.core.traversal.graph.TraversalVertex;
-import com.vaticle.typeql.lang.common.TypeQLArg.ValueType;
-import com.vaticle.typeql.lang.pattern.variable.Reference;
 
+import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN_VARIABLE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN_VARIABLE_VALUE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Type.ATTRIBUTE;
-import static com.vaticle.typeql.lang.common.TypeQLToken.Type.THING;
 
 public class TypeInference {
 
-    private final TraversalEngine traversalEng;
     private final LogicCache logicCache;
     private final GraphManager graphMgr;
+    private final TraversalEngine traversalEng;
 
     public TypeInference(LogicCache logicCache, TraversalEngine traversalEng, GraphManager graphMgr) {
-        this.traversalEng = traversalEng;
         this.logicCache = logicCache;
         this.graphMgr = graphMgr;
+        this.traversalEng = traversalEng;
     }
 
-    public FunctionalIterator<Map<Name, Label>> typePermutations(Conjunction conjunction, boolean insertable) {
-        TraversalBuilder traversalBuilder = new TraversalBuilder(conjunction, insertable, graphMgr);
-        GraphTraversal.Type traversal = traversalBuilder.traversal();
-        traversal.filter(traversalBuilder.retrievedResolvers());
-        return traversalEng.iterator(traversal).map(vertexMap -> {
-            Map<Name, Label> mapping = new HashMap<>();
-            vertexMap.forEach((id, vertex) -> {
-                assert vertex.isType();
-                traversalBuilder.getOriginalVariable(id).map(Variable::id).filter(Identifier::isName)
-                        .ifPresent(originalRef -> mapping.put(originalRef.asName(), vertex.asType().properLabel()));
-            });
-            return mapping;
-        });
+    public void infer(Disjunction disjunction) {
+        infer(disjunction, new HashMap<>());
     }
 
-    public void propagateLabels(Conjunction conj) {
+    private void infer(Disjunction disjunction, Map<Identifier.Variable.Name, Set<Label>> namedInferences) {
+        disjunction.conjunctions().forEach(conjunction -> infer(conjunction, namedInferences, false));
+    }
+
+    public void infer(Conjunction conjunction) {
+        infer(conjunction, false);
+    }
+
+    public void infer(Conjunction conjunction, boolean insertable) {
+        infer(conjunction, new HashMap<>(), insertable);
+    }
+
+    private void infer(Conjunction conjunction, Map<Identifier.Variable.Name, Set<Label>> scopingInferences, boolean insertable) {
+        propagateLabels(conjunction, graphMgr);
+        if (isSchemaQuery(conjunction)) return;
+        ConjunctionInference.run(conjunction, scopingInferences, insertable, logicCache, graphMgr, traversalEng);
+        if (!conjunction.negations().isEmpty()) {
+            Map<Retrievable.Name, Set<Label>> namedInferences = namedInferences(conjunction);
+            namedInferences.putAll(scopingInferences);
+            conjunction.negations().forEach(negation -> infer(negation.disjunction(), namedInferences));
+        }
+    }
+
+    private static void propagateLabels(Conjunction conj, GraphManager graphMgr) {
         iterate(conj.variables()).filter(v -> v.isType() && v.asType().label().isPresent()).forEachRemaining(typeVar -> {
             Label label = typeVar.asType().label().get().properLabel();
             if (label.scope().isPresent()) {
                 String scope = label.scope().get();
-                Set<Label> labels = traversalEng.graph().schema().resolveRoleTypeLabels(label);
+                Set<Label> labels = graphMgr.schema().resolveRoleTypeLabels(label);
                 if (labels.isEmpty()) throw TypeDBException.of(ROLE_TYPE_NOT_FOUND, label.name(), scope);
                 typeVar.addInferredTypes(labels);
             } else {
-                TypeVertex type = traversalEng.graph().schema().getType(label);
+                TypeVertex type = graphMgr.schema().getType(label);
                 if (type == null) throw TypeDBException.of(TYPE_NOT_FOUND, label);
                 typeVar.addInferredTypes(label);
             }
         });
     }
 
-    public void infer(Disjunction disjunction) {
-        infer(disjunction, new LinkedList<>());
-    }
-
-    private void infer(Disjunction disjunction, List<Conjunction> scopingConjunctions) {
-        disjunction.conjunctions().forEach(conjunction -> {
-            infer(conjunction, scopingConjunctions, false);
-            for (Negation negation : conjunction.negations()) {
-                infer(negation.disjunction(), list(scopingConjunctions, conjunction));
-            }
+    private Map<Retrievable.Name, Set<Label>> namedInferences(Conjunction conjunction) {
+        Map<Retrievable.Name, Set<Label>> namedInferences = new HashMap<>();
+        iterate(conjunction.variables()).filter(var -> var.id().isName()).forEachRemaining(var -> {
+            namedInferences.put(var.id().asName(), var.inferredTypes());
         });
-    }
-
-    public void infer(Conjunction conjunction, boolean insertable) {
-        infer(conjunction, list(), insertable);
-    }
-
-    private void infer(Conjunction conjunction, List<Conjunction> scopingConjunctions, boolean insertable) {
-        propagateLabels(conjunction);
-        if (isSchemaQuery(conjunction)) return;
-
-        TraversalBuilder builder = builder(conjunction, scopingConjunctions, graphMgr, insertable);
-        Optional<Map<Identifier.Variable.Retrievable, Set<Label>>> resolvedLabels = executeTypeResolvers(builder);
-        if (resolvedLabels.isEmpty()) conjunction.setCoherent(false);
-        else {
-            resolvedLabels.get().forEach((id, labels) -> builder.getOriginalVariable(id).ifPresent(variable -> {
-                assert variable.inferredTypes().isEmpty() || variable.inferredTypes().containsAll(labels);
-                variable.setInferredTypes(labels);
-            }));
-        }
+        return namedInferences;
     }
 
     private boolean isSchemaQuery(Conjunction conjunction) {
         return iterate(conjunction.variables()).noneMatch(Variable::isThing);
     }
 
-    private TraversalBuilder builder(Conjunction conjunction, List<Conjunction> scopingConjunctions, GraphManager graphMgr, boolean insertable) {
-        TraversalBuilder currentBuilder = null;
-        if (scopingConjunctions.isEmpty()) {
-            currentBuilder = new TraversalBuilder(conjunction, insertable, graphMgr);
-        } else {
-            Set<Reference.Name> names = iterate(conjunction.variables()).filter(v -> v.reference().isName())
-                    .map(v -> v.reference().asName()).toSet();
-            for (Conjunction scoping : scopingConjunctions) {
-                // only include conjunctions with a variable in common
-                if (iterate(scoping.variables()).anyMatch(v -> v.reference().isName() && names.contains(v.reference().asName()))) {
-                    if (currentBuilder == null) currentBuilder = new TraversalBuilder(scoping, insertable, graphMgr);
-                    else currentBuilder = new TraversalBuilder(scoping, currentBuilder, insertable, graphMgr);
-                }
-            }
-            currentBuilder = new TraversalBuilder(conjunction, currentBuilder, insertable, graphMgr);
-        }
-        currentBuilder.traversal().filter(currentBuilder.retrievedResolvers());
-        return currentBuilder;
-    }
-
-    private Optional<Map<Identifier.Variable.Retrievable, Set<Label>>> executeTypeResolvers(TraversalBuilder traversalBuilder) {
-        return logicCache.resolver().get(traversalBuilder.traversal().structure(), structure ->
-                traversalEng.combination(traversalBuilder.traversal(), requireConcreteTypes(traversalBuilder)).map(result -> {
-                            Map<Identifier.Variable.Retrievable, Set<Label>> mapping = new HashMap<>();
-                            result.forEach((id, types) -> {
-                                Optional<Variable> originalVar = traversalBuilder.getOriginalVariable(id);
-                                if (originalVar.isPresent()) {
-                                    Set<Label> labels = mapping.computeIfAbsent(id, (i) -> new HashSet<>());
-                                    types.forEach(vertex -> labels.add(vertex.properLabel()));
-                                }
-                            });
-                            return mapping;
-                        }
-                )
-        );
-    }
-
-    private Set<Identifier.Variable.Retrievable> requireConcreteTypes(TraversalBuilder traversalBuilder) {
-        return iterate(traversalBuilder.resolverToOriginal.values()).filter(Variable::isThing).map(var -> {
-            assert var.id().isRetrievable();
-            return var.id().asRetrievable();
-        }).toSet();
-    }
-
-    private static class TraversalBuilder {
+    private static class ConjunctionInference {
 
         private static final Identifier.Variable ROOT_ATTRIBUTE_ID = Identifier.Variable.label(ATTRIBUTE.toString());
-        private static final Identifier.Variable ROOT_THING_ID = Identifier.Variable.label(THING.toString());
-        private static final Label ROOT_ATTRIBUTE_LABEL = Label.of(ATTRIBUTE.toString());
-        private static final Label ROOT_THING_LABEL = Label.of(THING.toString());
-        private final Map<Identifier.Variable, Set<ValueType>> resolverValueTypes;
-        private final Map<Identifier.Variable, TypeVariable> originalToResolver;
-        private final Map<Identifier.Variable, Variable> resolverToOriginal;
-        private final GraphManager graphMgr;
+
         private final Conjunction conjunction;
-        private final GraphTraversal.Type traversal;
+        private final Map<Identifier.Variable.Name, Set<Label>> scopingInferences;
+        private final LogicCache logicCache;
+        private final GraphManager graphMgr;
+        private final TraversalEngine traversalEng;
         private final boolean insertable;
-        private boolean hasRootAttribute;
-        private boolean hasRootThing;
-        private int sysVarCounter;
 
-        TraversalBuilder(Conjunction conjunction, boolean insertable, GraphManager graphMgr) {
-            this(conjunction, new GraphTraversal.Type(), 0, insertable, graphMgr);
-        }
+        private final GraphTraversal.Type traversal;
+        private final Map<Identifier.Variable, TypeVariable> originalToInference;
+        private final Map<Identifier.Variable, Variable> inferenceToOriginal;
+        private int nextGeneratedID;
 
-        TraversalBuilder(Conjunction conjunction, TraversalBuilder scopingTraversal, boolean insertable, GraphManager graphMgr) {
-            this(conjunction, scopingTraversal.traversal(), scopingTraversal.sysVarCounter(), insertable, graphMgr);
-        }
-
-        private TraversalBuilder(Conjunction conjunction, GraphTraversal.Type initialTraversal, int initialSysVarCounter,
-                                 boolean insertable, GraphManager graphMgr) {
-            this.graphMgr = graphMgr;
+        private ConjunctionInference(Conjunction conjunction, Map<Identifier.Variable.Name, Set<Label>> scopingInferences,
+                                     boolean insertable, LogicCache logicCache, GraphManager graphMgr, TraversalEngine traversalEng) {
             this.conjunction = conjunction;
-            this.traversal = initialTraversal;
-            this.resolverToOriginal = new HashMap<>();
-            this.originalToResolver = new HashMap<>();
-            this.resolverValueTypes = new HashMap<>();
-            this.sysVarCounter = initialSysVarCounter;
+            this.scopingInferences = scopingInferences;
+            this.logicCache = logicCache;
+            this.graphMgr = graphMgr;
+            this.traversalEng = traversalEng;
             this.insertable = insertable;
-            this.hasRootAttribute = false;
-            this.hasRootThing = false;
-            conjunction.variables().forEach(this::register);
+            this.traversal = new GraphTraversal.Type();
+            this.originalToInference = new HashMap<>();
+            this.inferenceToOriginal = new HashMap<>();
+            this.nextGeneratedID = largestAnonymousVar(conjunction) + 1;
+            conjunction.variables().forEach(this::toInferenceVar);
+            traversal.filter(iterate(inferenceToOriginal.keySet()).filter(Identifier::isRetrievable).map(Identifier.Variable::asRetrievable).toSet());
         }
 
-        public Set<Identifier.Variable.Retrievable> retrievedResolvers() {
-            return iterate(resolverToOriginal.keySet()).filter(Identifier::isRetrievable).map(Identifier.Variable::asRetrievable).toSet();
+        static void run(Conjunction conjunction, Map<Identifier.Variable.Name, Set<Label>> scopingInferences,
+                        boolean insertable, LogicCache logicCache, GraphManager graphMgr, TraversalEngine traversalEng) {
+            ConjunctionInference conjunctionInference = new ConjunctionInference(
+                    conjunction, scopingInferences, insertable, logicCache, graphMgr, traversalEng
+            );
+            conjunctionInference.runInference();
         }
 
-        public int sysVarCounter() {
-            return sysVarCounter;
+        private static int largestAnonymousVar(Conjunction conjunction) {
+            return iterate(conjunction.variables()).filter(var -> var.id().isAnonymous())
+                    .map(var -> var.id().asAnonymous().anonymousId()).stream().max(Comparator.naturalOrder()).orElse(0);
         }
 
-        GraphTraversal.Type traversal() {
-            return traversal;
+        private void runInference() {
+            Optional<Map<Retrievable, Set<Label>>> inferredTypes = logicCache.inference().get(
+                    traversal,
+                    traversal -> traversalEng.combination(traversal, thingInferenceVars()).map(this::toLabels)
+            );
+            if (inferredTypes.isPresent()) applyInferredTypes(inferredTypes.get());
+            else conjunction.setCoherent(false);
         }
 
-        Optional<Variable> getOriginalVariable(Identifier.Variable id) {
-            return Optional.ofNullable(resolverToOriginal.get(id));
+        private Set<Identifier.Variable.Retrievable> thingInferenceVars() {
+            return iterate(conjunction.variables()).filter(Variable::isThing).map(var ->
+                    originalToInference.get(var.id()).id().asRetrievable()
+            ).toSet();
         }
 
-        private void register(Variable variable) {
-            if (variable.isType()) register(variable.asType());
-            else if (variable.isThing()) register(variable.asThing());
+        private void applyInferredTypes(Map<Retrievable, Set<Label>> inferredTypes) {
+            conjunction.variables().forEach(var -> {
+                Identifier.Variable inferenceID = originalToInference.get(var.id()).id();
+                if (inferenceID != null && inferenceID.isRetrievable()) {
+                    var.setInferredTypes(inferredTypes.get(inferenceID.asRetrievable()));
+                }
+            });
+        }
+
+        private Map<Retrievable, Set<Label>> toLabels(Map<Retrievable, Set<TypeVertex>> types) {
+            HashMap<Retrievable, Set<Label>> labels = new HashMap<>();
+            types.forEach((id, ts) -> labels.put(id, iterate(ts).map(TypeVertex::properLabel).toSet()));
+            return labels;
+        }
+
+        private void toInferenceVar(Variable variable) {
+            if (variable.isType()) toInferenceVar(variable.asType());
+            else if (variable.isThing()) toInferenceVar(variable.asThing());
             else throw TypeDBException.of(ILLEGAL_STATE);
         }
 
-        private TypeVariable register(TypeVariable var) {
-            if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
-            TypeVariable resolver;
-            if (var.label().isPresent() && var.label().get().scope().isPresent()) {
-                resolver = new TypeVariable(newSystemId());
-                traversal.labels(resolver.id(), var.inferredTypes());
-            } else {
-                resolver = var;
+        private TypeVariable toInferenceVar(TypeVariable var) {
+            if (originalToInference.containsKey(var.id())) return originalToInference.get(var.id());
+
+            TypeVariable inferenceVar = new TypeVariable(generateVariableID());
+            originalToInference.put(var.id(), inferenceVar);
+            inferenceToOriginal.putIfAbsent(inferenceVar.id(), var);
+            if (!var.inferredTypes().isEmpty()) restrictTypes(inferenceVar.id(), iterate(var.inferredTypes()));
+            if (var.id().isName() && scopingInferences.containsKey(var.id().asName())) {
+                restrictTypes(inferenceVar.id(), iterate(scopingInferences.get(var.id().asName())));
             }
-            originalToResolver.put(var.id(), resolver);
-            resolverToOriginal.putIfAbsent(resolver.id(), var);
-            if (!var.inferredTypes().isEmpty()) traversal.labels(resolver.id(), var.inferredTypes());
 
             for (TypeConstraint constraint : var.constraints()) {
-                if (constraint.isAbstract()) registerAbstract(resolver);
-                else if (constraint.isIs()) registerIsType(resolver, constraint.asIs());
-                else if (constraint.isOwns()) registerOwns(resolver, constraint.asOwns());
-                else if (constraint.isPlays()) registerPlays(resolver, constraint.asPlays());
-                else if (constraint.isRegex()) registerRegex(resolver, constraint.asRegex());
-                else if (constraint.isRelates()) registerRelates(resolver, constraint.asRelates());
-                else if (constraint.isSub()) registerSub(resolver, constraint.asSub());
-                else if (constraint.isValueType()) registerValueType(resolver, constraint.asValueType());
+                if (constraint.isAbstract()) registerAbstract(inferenceVar);
+                else if (constraint.isIs()) registerIsType(inferenceVar, constraint.asIs());
+                else if (constraint.isOwns()) registerOwns(inferenceVar, constraint.asOwns());
+                else if (constraint.isPlays()) registerPlays(inferenceVar, constraint.asPlays());
+                else if (constraint.isRegex()) registerRegex(inferenceVar, constraint.asRegex());
+                else if (constraint.isRelates()) registerRelates(inferenceVar, constraint.asRelates());
+                else if (constraint.isSub()) registerSub(inferenceVar, constraint.asSub());
+                else if (constraint.isValueType()) registerValueType(inferenceVar, constraint.asValueType());
                 else if (!constraint.isLabel()) throw TypeDBException.of(ILLEGAL_STATE);
             }
-
-            return resolver;
+            return inferenceVar;
         }
 
         private void registerAbstract(TypeVariable resolver) {
@@ -294,74 +246,177 @@ public class TypeInference {
         }
 
         private void registerIsType(TypeVariable resolver, com.vaticle.typedb.core.pattern.constraint.type.IsConstraint isConstraint) {
-            traversal.equalTypes(resolver.id(), register(isConstraint.variable()).id());
+            traversal.equalTypes(resolver.id(), toInferenceVar(isConstraint.variable()).id());
         }
 
-        private void restrict(Identifier.Variable id, FunctionalIterator<TypeVertex> types) {
+        private void registerOwns(TypeVariable inferenceVar, OwnsConstraint ownsConstraint) {
+            TypeVariable attrVar = toInferenceVar(ownsConstraint.attribute());
+            traversal.owns(inferenceVar.id(), attrVar.id(), ownsConstraint.isKey());
+        }
+
+        private void registerPlays(TypeVariable inferenceVar, PlaysConstraint playsConstraint) {
+            TypeVariable roleVar = toInferenceVar(playsConstraint.role());
+            traversal.plays(inferenceVar.id(), roleVar.id());
+        }
+
+        private void registerRegex(TypeVariable inferenceVar, RegexConstraint regexConstraint) {
+            traversal.regex(inferenceVar.id(), regexConstraint.regex().pattern());
+            restrictTypes(inferenceVar.id(), graphMgr.schema().attributeTypes(Encoding.ValueType.STRING)
+                    .map(TypeVertex::properLabel));
+        }
+
+        private void registerRelates(TypeVariable inferenceVar, RelatesConstraint relatesConstraint) {
+            TypeVariable roleVar = toInferenceVar(relatesConstraint.role());
+            traversal.relates(inferenceVar.id(), roleVar.id());
+        }
+
+        private void registerSub(TypeVariable inferenceVar, SubConstraint subConstraint) {
+            TypeVariable superVar = toInferenceVar(subConstraint.type());
+            traversal.sub(inferenceVar.id(), superVar.id(), !subConstraint.isExplicit());
+        }
+
+        private void registerValueType(TypeVariable resolver, ValueTypeConstraint valueTypeConstraint) {
+            traversal.valueType(resolver.id(), valueTypeConstraint.valueType());
+            restrictTypesByValueType(resolver, set(Encoding.ValueType.of(valueTypeConstraint.valueType())));
+        }
+
+
+        private TypeVariable toInferenceVar(ThingVariable var) {
+            if (originalToInference.containsKey(var.id())) return originalToInference.get(var.id());
+
+            TypeVariable inferenceVar = new TypeVariable(var.id());
+            originalToInference.put(var.id(), inferenceVar);
+            inferenceToOriginal.putIfAbsent(inferenceVar.id(), var);
+            if (var.id().isName() && scopingInferences.containsKey(var.id().asName())) {
+                restrictTypes(inferenceVar.id(), iterate(scopingInferences.get(var.id().asName())));
+            }
+
+            var.value().forEach(constraint -> registerValue(inferenceVar, constraint));
+            var.isa().ifPresent(constraint -> registerIsa(inferenceVar, constraint));
+            var.is().forEach(constraint -> registerIs(inferenceVar, constraint));
+            var.has().forEach(constraint -> registerHas(inferenceVar, constraint));
+            if (insertable)
+                var.relation().ifPresent(constraint -> registerInsertableRelation(inferenceVar, constraint));
+            else var.relation().ifPresent(constraint -> registerRelation(inferenceVar, constraint));
+            var.iid().ifPresent(constraint -> registerIID(inferenceVar, constraint));
+            return inferenceVar;
+        }
+
+        private void registerValue(TypeVariable inferenceVar, ValueConstraint<?> constraint) {
+            Set<Encoding.ValueType> comparableValueTypes;
+            if (constraint.isVariable()) {
+                TypeVariable comparableVar = toInferenceVar(constraint.asVariable().value());
+                registerSubAttribute(comparableVar);
+                comparableValueTypes = traversal.structure().typeVertex(comparableVar.id()).props().valueTypes();
+            } else {
+                comparableValueTypes = set(Encoding.ValueType.of(constraint.value().getClass()));
+            }
+
+            Set<Encoding.ValueType> valueTypes = iterate(comparableValueTypes)
+                    .flatMap(valueType -> iterate(valueType.comparables())).toSet();
+            if (!valueTypes.isEmpty()) {
+                restrictValueTypes(inferenceVar.id(), iterate(valueTypes));
+                restrictTypesByValueType(inferenceVar, valueTypes);
+            }
+            registerSubAttribute(inferenceVar);
+        }
+
+        private void registerIsa(TypeVariable inferenceVar, IsaConstraint isaConstraint) {
+            if (!isaConstraint.isExplicit() && !insertable) {
+                traversal.sub(inferenceVar.id(), toInferenceVar(isaConstraint.type()).id(), true);
+            } else if (isaConstraint.type().id().isName() || isaConstraint.type().id().isLabel()) {
+                traversal.equalTypes(inferenceVar.id(), toInferenceVar(isaConstraint.type()).id());
+            } else {
+                throw TypeDBException.of(ILLEGAL_STATE);
+            }
+        }
+
+        private void registerIs(TypeVariable inferenceVar, IsConstraint isConstraint) {
+            traversal.equalTypes(inferenceVar.id(), toInferenceVar(isConstraint.variable()).id());
+        }
+
+        /**
+         * We only extract the type of the IID, and include this information in the type inference
+         * We only look at the type prefix because the static type checker (this class) only read schema, not data
+         */
+        private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
+            TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
+            if (type == null) {
+                conjunction.setCoherent(false);
+                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
+            }
+            restrictTypes(resolver.id(), iterate(type).map(TypeVertex::properLabel));
+        }
+
+        private void registerHas(TypeVariable inferenceVar, HasConstraint hasConstraint) {
+            TypeVariable attrVar = toInferenceVar(hasConstraint.attribute());
+            traversal.owns(inferenceVar.id(), attrVar.id(), false);
+            registerSubAttribute(attrVar);
+        }
+
+        private void registerRelation(TypeVariable inferenceVar, RelationConstraint constraint) {
+            for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
+                TypeVariable playerVar = toInferenceVar(rolePlayer.player());
+                TypeVariable roleInstanceVar = new TypeVariable(generateVariableID());
+                if (rolePlayer.roleType().isPresent()) {
+                    TypeVariable roleTypeVar = toInferenceVar(rolePlayer.roleType().get());
+                    traversal.sub(roleInstanceVar.id(), roleTypeVar.id(), true);
+                }
+                traversal.relates(inferenceVar.id(), roleInstanceVar.id());
+                traversal.plays(playerVar.id(), roleInstanceVar.id());
+            }
+        }
+
+        private void registerInsertableRelation(TypeVariable inferenceVar, RelationConstraint constraint) {
+            for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
+                TypeVariable playerVar = toInferenceVar(rolePlayer.player());
+                TypeVariable roleTypeVar;
+                if (rolePlayer.roleType().isPresent()) {
+                    roleTypeVar = toInferenceVar(rolePlayer.roleType().get());
+                } else {
+                    roleTypeVar = new TypeVariable(generateVariableID());
+                }
+                traversal.relates(inferenceVar.id(), roleTypeVar.id());
+                traversal.plays(playerVar.id(), roleTypeVar.id());
+            }
+        }
+
+        private void registerSubAttribute(Variable inferenceVar) {
+            traversal.labels(ROOT_ATTRIBUTE_ID, Label.of(ATTRIBUTE.toString()));
+            traversal.sub(inferenceVar.id(), ROOT_ATTRIBUTE_ID, true);
+        }
+
+        private void restrictTypes(Identifier.Variable id, FunctionalIterator<Label> labels) {
             TraversalVertex.Properties.Type props = traversal.structure().typeVertex(id).props();
-            Set<Label> existingLabels = props.labels();
-            if (existingLabels.isEmpty()) types.forEachRemaining(t -> existingLabels.add(t.properLabel()));
+            if (props.labels().isEmpty()) labels.forEachRemaining(props.labels()::add);
             else {
-                Set<Label> intersection = types.filter(t -> existingLabels.contains(t.properLabel()))
-                        .map(TypeVertex::properLabel).toSet();
+                Set<Label> intersection = labels.filter(props.labels()::contains).toSet();
                 props.clearLabels();
                 props.labels(intersection);
             }
             if (props.labels().isEmpty()) {
                 conjunction.setCoherent(false);
-                throw TypeDBException.of(UNSATISFIABLE_PATTERN_VARIABLE, conjunction, resolverToOriginal.get(id));
+                throw TypeDBException.of(UNSATISFIABLE_PATTERN_VARIABLE, conjunction, inferenceToOriginal.get(id));
             }
         }
 
-        private void registerOwns(TypeVariable resolver, OwnsConstraint ownsConstraint) {
-            TypeVariable attrResolver = register(ownsConstraint.attribute());
-            traversal.owns(resolver.id(), attrResolver.id(), ownsConstraint.isKey());
-            restrict(resolver.id(), graphMgr.schema().attributeOwnerTypes());
-            restrict(attrResolver.id(), graphMgr.schema().attributeTypesOwned());
-        }
-
-        private void registerPlays(TypeVariable resolver, PlaysConstraint playsConstraint) {
-            TypeVariable roleResolver = register(playsConstraint.role());
-            traversal.plays(resolver.id(), roleResolver.id());
-            restrict(resolver.id(), graphMgr.schema().playerTypes());
-            restrict(roleResolver.id(), graphMgr.schema().roleTypesPlayed());
-        }
-
-        private void registerRegex(TypeVariable resolver, RegexConstraint regexConstraint) {
-            traversal.regex(resolver.id(), regexConstraint.regex().pattern());
-            restrict(resolver.id(), graphMgr.schema().attributeTypes(Encoding.ValueType.STRING));
-        }
-
-        private void registerRelates(TypeVariable resolver, RelatesConstraint relatesConstraint) {
-            TypeVariable roleResolver = register(relatesConstraint.role());
-            traversal.relates(resolver.id(), roleResolver.id());
-            restrict(resolver.id(), graphMgr.schema().relationTypes());
-            restrict(roleResolver.id(), graphMgr.schema().roleTypes());
-        }
-
-        private void registerSub(TypeVariable resolver, SubConstraint subConstraint) {
-            TypeVariable superResolver = register(subConstraint.type());
-            traversal.sub(resolver.id(), superResolver.id(), !subConstraint.isExplicit());
-            if (superResolver.id().isLabel()) {
-                assert superResolver.label().isPresent();
-                if (!subConstraint.isExplicit()) {
-                    restrict(resolver.id(), graphMgr.schema().getSubtypes(
-                            graphMgr.schema().getType(superResolver.label().get().properLabel())));
-                } else {
-                    restrict(resolver.id(), graphMgr.schema().getType(superResolver.label().get().properLabel())
-                            .ins().edge(Encoding.Edge.Type.SUB).from());
-                }
+        private void restrictValueTypes(Identifier.Variable id, FunctionalIterator<Encoding.ValueType> valueTypes) {
+            TraversalVertex.Properties.Type props = traversal.structure().typeVertex(id).props();
+            if (props.valueTypes().isEmpty()) valueTypes.forEachRemaining(props.valueTypes()::add);
+            else {
+                Set<Encoding.ValueType> intersection = valueTypes.filter(props.valueTypes()::contains).toSet();
+                props.clearValueTypes();
+                props.valueTypes(intersection);
+            }
+            if (props.valueTypes().isEmpty()) {
+                conjunction.setCoherent(false);
+                throw TypeDBException.of(UNSATISFIABLE_PATTERN_VARIABLE_VALUE, conjunction, inferenceToOriginal.get(id));
             }
         }
 
-        private void registerValueType(TypeVariable resolver, ValueTypeConstraint valueTypeConstraint) {
-            traversal.valueType(resolver.id(), valueTypeConstraint.valueType());
-            inferTypesByValueType(resolver, set(valueTypeConstraint.valueType()));
-        }
-
-        private void inferTypesByValueType(TypeVariable resolver, Set<ValueType> valueTypes) {
+        private void restrictTypesByValueType(TypeVariable resolver, Set<Encoding.ValueType> valueTypes) {
             FunctionalIterator<TypeVertex> attrTypes = empty();
-            for (ValueType valueType : valueTypes) {
+            for (Encoding.ValueType valueType : valueTypes) {
                 switch (valueType) {
                     case STRING:
                         attrTypes = attrTypes.link(graphMgr.schema().attributeTypes(Encoding.ValueType.STRING));
@@ -382,161 +437,11 @@ public class TypeInference {
                         throw TypeDBException.of(ILLEGAL_STATE);
                 }
             }
-            restrict(resolver.id(), attrTypes);
+            restrictTypes(resolver.id(), attrTypes.map(TypeVertex::properLabel));
         }
 
-
-        private TypeVariable register(ThingVariable var) {
-            if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
-
-            TypeVariable resolver = new TypeVariable(var.id());
-            originalToResolver.put(var.id(), resolver);
-            resolverToOriginal.putIfAbsent(resolver.id(), var);
-            resolverValueTypes.putIfAbsent(resolver.id(), set());
-
-            // Note: order is important! convertValue assumes that any other Variable encountered from that edge will
-            // have resolved its valueType, so we execute convertValue first.
-            var.value().forEach(constraint -> registerValue(resolver, constraint));
-            var.isa().ifPresent(constraint -> registerIsa(resolver, constraint));
-            var.is().forEach(constraint -> registerIs(resolver, constraint));
-            var.has().forEach(constraint -> registerHas(resolver, constraint));
-            if (insertable) var.relation().ifPresent(constraint -> registerInsertableRelation(resolver, constraint));
-            else var.relation().ifPresent(constraint -> registerRelation(resolver, constraint));
-            var.iid().ifPresent(constraint -> {
-                registerIID(resolver, constraint);
-                if (resolver.constraints().isEmpty()) registerSubThing(resolver);
-            });
-            return resolver;
-        }
-
-        private void registerSubThing(TypeVariable resolver) {
-            assert resolver.constraints().isEmpty();
-            registerRootThing();
-            traversal.sub(resolver.id(), ROOT_THING_ID, true);
-        }
-
-        private void registerIsa(TypeVariable resolver, IsaConstraint isaConstraint) {
-            if (!isaConstraint.isExplicit() && !insertable) {
-                traversal.sub(resolver.id(), register(isaConstraint.type()).id(), true);
-            } else if (isaConstraint.type().id().isName() || isaConstraint.type().id().isLabel()) {
-                traversal.equalTypes(resolver.id(), register(isaConstraint.type()).id());
-            } else {
-                throw TypeDBException.of(ILLEGAL_STATE);
-            }
-            if (isaConstraint.type().label().isPresent()) {
-                restrict(resolver.id(), graphMgr.schema().getSubtypes(
-                        graphMgr.schema().getType(isaConstraint.type().label().get().properLabel())));
-            }
-        }
-
-        private void registerIs(TypeVariable resolver, IsConstraint isConstraint) {
-            traversal.equalTypes(resolver.id(), register(isConstraint.variable()).id());
-        }
-
-        /**
-         * We only extract the type of the IID, and include this information in the type inference
-         * We only look at the type prefix because the static type checker (this class) only read schema, not data
-         */
-        private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
-            TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
-            if (type == null) {
-                conjunction.setCoherent(false);
-                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
-            }
-            restrict(resolver.id(), iterate(type));
-        }
-
-        private void registerHas(TypeVariable resolver, HasConstraint hasConstraint) {
-            TypeVariable attributeResolver = register(hasConstraint.attribute());
-            traversal.owns(resolver.id(), attributeResolver.id(), false);
-            registerSubAttribute(attributeResolver);
-            restrict(resolver.id(), graphMgr.schema().attributeOwnerTypes());
-            restrict(attributeResolver.id(), graphMgr.schema().attributeTypesOwned());
-        }
-
-        private void registerRelation(TypeVariable resolver, RelationConstraint constraint) {
-            for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
-                TypeVariable playerResolver = register(rolePlayer.player());
-                TypeVariable actingRoleResolver = new TypeVariable(newSystemId());
-                if (rolePlayer.roleType().isPresent()) {
-                    TypeVariable roleTypeResolver = register(rolePlayer.roleType().get());
-                    traversal.sub(actingRoleResolver.id(), roleTypeResolver.id(), true);
-                    restrict(roleTypeResolver.id(), graphMgr.schema().roleTypes());
-                    restrict(actingRoleResolver.id(), graphMgr.schema().roleTypes());
-                }
-                traversal.relates(resolver.id(), actingRoleResolver.id());
-                traversal.plays(playerResolver.id(), actingRoleResolver.id());
-                restrict(playerResolver.id(), graphMgr.schema().playerTypes());
-            }
-            restrict(resolver.id(), graphMgr.schema().relationTypes());
-        }
-
-        private void registerInsertableRelation(TypeVariable resolver, RelationConstraint constraint) {
-            for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
-                TypeVariable playerResolver = register(rolePlayer.player());
-                TypeVariable roleResolver = register(rolePlayer.roleType().isPresent() ?
-                        rolePlayer.roleType().get() : new TypeVariable(newSystemId()));
-                traversal.relates(resolver.id(), roleResolver.id());
-                traversal.plays(playerResolver.id(), roleResolver.id());
-            }
-            restrict(resolver.id(), graphMgr.schema().relationTypes());
-        }
-
-        private void registerValue(TypeVariable resolver, ValueConstraint<?> constraint) {
-            Set<ValueType> valueTypes;
-            if (constraint.isVariable()) {
-                TypeVariable comparableVar = register(constraint.asVariable().value());
-                assert resolverValueTypes.containsKey(comparableVar.id()); //This will fail without careful ordering.
-                registerSubAttribute(comparableVar);
-                valueTypes = resolverValueTypes.get(comparableVar.id());
-            } else {
-                valueTypes = iterate(Encoding.ValueType.of(constraint.value().getClass()).comparables())
-                        .map(Encoding.ValueType::typeQLValueType).toSet();
-            }
-
-            if (!valueTypes.isEmpty() && resolverValueTypes.get(resolver.id()).isEmpty()) {
-                traversal.valueType(resolver.id(), valueTypes);
-                inferTypesByValueType(resolver, valueTypes);
-                resolverValueTypes.put(resolver.id(), valueTypes);
-            } else if (!resolverValueTypes.get(resolver.id()).containsAll(valueTypes)) {
-                conjunction.setCoherent(false);
-                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
-            }
-            registerSubAttribute(resolver);
-        }
-
-        private void registerSubAttribute(Variable resolver) {
-            assert resolverToOriginal.get(resolver.id()).isThing();
-            Optional<IsaConstraint> isa = resolverToOriginal.get(resolver.id()).asThing().isa();
-            if (!isa.isPresent()) {
-                registerRootAttribute();
-                traversal.sub(resolver.id(), ROOT_ATTRIBUTE_ID, true);
-            } else {
-                Optional<LabelConstraint> labelCons = isa.get().type().label();
-                if (labelCons.isPresent() && !labelCons.get().properLabel().equals(ROOT_ATTRIBUTE_LABEL) &&
-                        !labelCons.get().properLabel().equals(ROOT_THING_LABEL)) {
-                    registerRootAttribute();
-                    traversal.sub(register(isa.get().type()).id(), ROOT_ATTRIBUTE_ID, true);
-                }
-            }
-        }
-
-        private void registerRootAttribute() {
-            if (!hasRootAttribute) {
-                traversal.labels(ROOT_ATTRIBUTE_ID, ROOT_ATTRIBUTE_LABEL);
-                hasRootAttribute = true;
-            }
-        }
-
-        private void registerRootThing() {
-            if (!hasRootThing) {
-                traversal.labels(ROOT_THING_ID, ROOT_THING_LABEL);
-                hasRootThing = true;
-            }
-        }
-
-        private Identifier.Variable newSystemId() {
-            return Identifier.Variable.of(SystemReference.of(sysVarCounter++));
+        private Identifier.Variable generateVariableID() {
+            return Identifier.Variable.anon(nextGeneratedID++);
         }
     }
 }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -18,7 +18,9 @@
 
 package com.vaticle.typedb.core.pattern.constraint.thing;
 
+import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.equivalence.AlphaEquivalence;
 import com.vaticle.typedb.core.pattern.equivalence.AlphaEquivalent;
@@ -108,10 +110,14 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
     }
 
     @Override
-    public boolean isRelation() { return true; }
+    public boolean isRelation() {
+        return true;
+    }
 
     @Override
-    public RelationConstraint asRelation() { return this; }
+    public RelationConstraint asRelation() {
+        return this;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -157,13 +163,15 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         private final ThingVariable player;
         private final int repetition;
         private final int hash;
+        private Set<Label> inferredRoleTypes;
 
         public RolePlayer(@Nullable TypeVariable roleType, ThingVariable player, int repetition) {
-            assert roleType == null || roleType.reference().isName() ||
+            assert roleType == null || roleType.id().isName() ||
                     (roleType.label().isPresent() && roleType.label().get().scope().isPresent());
             if (player == null) throw new NullPointerException("Null player");
             this.roleType = roleType;
             this.player = player;
+            this.inferredRoleTypes = null;
             this.repetition = repetition;
             this.hash = Objects.hash(this.roleType, this.player, this.repetition);
         }
@@ -191,6 +199,17 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
         public Optional<TypeVariable> roleType() {
             return Optional.ofNullable(roleType);
+        }
+
+        public Set<Label> inferredRoleTypes() {
+            assert inferredRoleTypes != null ^ roleType != null;
+            if (inferredRoleTypes == null) return roleType.inferredTypes();
+            else return inferredRoleTypes;
+        }
+
+        public void setInferredRoleTypes(Set<Label> roleTypes) {
+            assert roleType == null;
+            this.inferredRoleTypes = roleTypes;
         }
 
         public ThingVariable player() {

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -1083,12 +1083,6 @@ public class TypeInferenceTest {
         String queryString = "match (partner: $x);";
         Disjunction disjunction = createDisjunction(queryString);
         Conjunction conjunction = disjunction.conjunctions().get(0);
-        typeInference.propagateLabels(conjunction);
-
-        Set<String> expectedLabels = set("partnership:partner", "business:partner");
-
-        assertEquals(expectedLabels, resolvedTypeMap(conjunction).get("$_relation:partner"));
-
         typeInference.infer(conjunction, false);
         Set<String> expectedResolvedTypes = set("partnership:partner");
 

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -218,7 +218,7 @@ public abstract class Identifier {
 
         public static abstract class Retrievable extends Variable {
 
-            public Retrievable(Reference reference, Integer id) {
+            Retrievable(Reference reference, Integer id) {
                 super(reference, id);
             }
 
@@ -270,6 +270,10 @@ public abstract class Identifier {
 
             public String name() {
                 return reference().name() + id;
+            }
+
+            public int anonymousId() {
+                return id;
             }
 
             @Override

--- a/traversal/graph/TraversalVertex.java
+++ b/traversal/graph/TraversalVertex.java
@@ -217,8 +217,16 @@ public abstract class TraversalVertex<EDGE extends TraversalEdge<?, ?>, PROPERTI
                 return valueTypes;
             }
 
+            public void clearValueTypes() {
+                this.valueTypes.clear();
+            }
+
             public void valueType(Encoding.ValueType valueType) {
                 this.valueTypes.add(valueType);
+            }
+
+            public void valueTypes(Set<Encoding.ValueType> valueTypes) {
+                this.valueTypes.addAll(valueTypes);
             }
 
             public Optional<String> regex() {

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -1212,8 +1212,7 @@ public abstract class ProcedureEdge<
                                 filteredIID = true;
                                 ThingVertex player = graphMgr.data().getReadable(params.getIID(to.id().asVariable()));
                                 if (player == null) return empty();
-                                // TODO: the following code can be optimised if we have an API to directly get the
-                                //       roleplayer edge when we have the roleplayer vertex
+                                // TODO we should use the exact type of the current vertex to restrict the set of role types possible
                                 iter = resolveRoleTypesIter.mergeMap(
                                         ASC,
                                         rt -> rel.outs()


### PR DESCRIPTION
## What is the goal of this PR?

In order to faciliate updating and modifying type inference in the future, we clean up technical debt related to the implementation of type inference. This largely included simplifying various awkward implementation details and restructuring the entry point of type inference.

## What are the changes implemented in this PR?

* simplify type inference, by removing various unneeded part of the type inference traversal and the entry point
* fix a bug in the Combination algorithm