### PR TITLE
Introduce directed In and Out type adjacencies

### DIFF
--- a/common/iterator/AbstractFunctionalIterator.java
+++ b/common/iterator/AbstractFunctionalIterator.java
@@ -231,7 +231,7 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
     }
 
     @Override
-    public FunctionalIterator<T> onFinalise(Runnable function) {
+    public FunctionalIterator<T> onFinalised(Runnable function) {
         return new FinaliseIterator<>(this, function);
     }
 

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -91,7 +91,7 @@ public interface FunctionalIterator<T> extends Iterator<T> {
 
     FunctionalIterator<T> onError(Function<Exception, TypeDBException> exceptionFn);
 
-    FunctionalIterator<T> onFinalise(Runnable function);
+    FunctionalIterator<T> onFinalised(Runnable function);
 
     void recycle();
 

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -165,7 +165,7 @@ public class Iterators {
         public static class Seekable {
 
             public static <T extends Comparable<T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
-                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<>());
+                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
             }
 
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -20,14 +20,14 @@ package com.vaticle.typedb.core.common.iterator;
 
 import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.core.common.iterator.sorted.BaseSortedIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.BasedSeekableIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.BaseSeekableIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.ConsumeHandledSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.DistinctSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FilteredSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FinaliseSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.MappedSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.MergeMappedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 
 import java.util.ArrayList;
@@ -113,7 +113,6 @@ public class Iterators {
         return StreamSupport.stream(spliteratorUnknownSize(iterator, ORDERED | IMMUTABLE), false);
     }
 
-
     public static int compareSize(Iterator<?> iterator, int size) {
         long count = 0L;
         while (iterator.hasNext()) {
@@ -126,16 +125,8 @@ public class Iterators {
 
     public static class Sorted {
 
-        public static <T extends Comparable<T>> Seekable<T, Order.Asc> emptySorted() {
-            return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
-        }
-
         public static <T extends Comparable<T>, ORDER extends Order> SortedIterator<T, ORDER> iterateSorted(ORDER order, List<T> list) {
             return new BaseSortedIterator<>(order, list);
-        }
-
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {
-            return new BasedSeekableIterator<>(order, set);
         }
 
         public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> distinct(
@@ -143,18 +134,9 @@ public class Iterators {
             return new DistinctSortedIterator<>(iterator);
         }
 
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> distinct(Seekable<T, ORDER> iterator) {
-            return new DistinctSortedIterator.Seekable<>(iterator);
-        }
-
         public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> filter(
                 SortedIterator<T, ORDER> iterator, Predicate<T> predicate) {
             return new FilteredSortedIterator<>(iterator, predicate);
-        }
-
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> filter(Seekable<T, ORDER> iterator,
-                                                                                                       Predicate<T> predicate) {
-            return new FilteredSortedIterator.Seekable<>(iterator, predicate);
         }
 
         public static <T extends Comparable<? super T>, U extends Comparable<? super U>, ORDER extends Order>
@@ -162,23 +144,48 @@ public class Iterators {
             return new MappedSortedIterator<>(order, iterator, mappingFn);
         }
 
-        public static <T extends Comparable<? super T>, U extends Comparable<? super U>, ORDER extends Order>
-        Seekable<U, ORDER> mapSorted(ORDER order, Seekable<T, ?> iterator, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
-            return new MappedSortedIterator.Seekable<>(order, iterator, mappingFn, reverseMappingFn);
-        }
+        public static class Seekable {
 
-        @SafeVarargs
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> merge(Seekable<T, ORDER> iterator, Seekable<T, ORDER>... iterators) {
-            return new MergeMappedIterator.Seekable<>(iterator.order(), iterate(list(list(iterators), iterator)), e -> e);
-        }
+            public static <T extends Comparable<T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
+                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
+            }
 
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> merge(ORDER order, FunctionalIterator<Seekable<T, ORDER>> iterators) {
-            return new MergeMappedIterator.Seekable<>(order, iterators, e -> e);
-        }
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {
+                return new BaseSeekableIterator<>(order, set);
+            }
 
-        public static <T extends Comparable<? super T>, ORDER extends Order> Seekable<T, ORDER> onFinalise(Seekable<T, ORDER> iterator,
-                                                                                                           Runnable finalise) {
-            return new FinaliseSortedIterator.Seekable<>(iterator, finalise);
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> distinct(SortedIterator.Seekable<T, ORDER> iterator) {
+                return new DistinctSortedIterator.Seekable<>(iterator);
+            }
+
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> filter(SortedIterator.Seekable<T, ORDER> iterator,
+                                                                                                                          Predicate<T> predicate) {
+                return new FilteredSortedIterator.Seekable<>(iterator, predicate);
+            }
+
+            @SafeVarargs
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> merge(SortedIterator.Seekable<T, ORDER> iterator, SortedIterator.Seekable<T, ORDER>... iterators) {
+                return new MergeMappedIterator.Seekable<>(iterator.order(), iterate(list(list(iterators), iterator)), e -> e);
+            }
+
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> merge(ORDER order, FunctionalIterator<SortedIterator.Seekable<T, ORDER>> iterators) {
+                return new MergeMappedIterator.Seekable<>(order, iterators, e -> e);
+            }
+
+            public static <T extends Comparable<? super T>, U extends Comparable<? super U>, ORDER extends Order>
+            SortedIterator.Seekable<U, ORDER> mapSorted(ORDER order, SortedIterator.Seekable<T, ?> iterator, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
+                return new MappedSortedIterator.Seekable<>(order, iterator, mappingFn, reverseMappingFn);
+            }
+
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> onConsume(SortedIterator.Seekable<T, ORDER> iterator,
+                                                                                                                             Runnable onConsume) {
+                return new ConsumeHandledSortedIterator.Seekable<>(iterator, onConsume);
+            }
+
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> onFinalise(SortedIterator.Seekable<T, ORDER> iterator,
+                                                                                                                              Runnable finalise) {
+                return new FinaliseSortedIterator.Seekable<>(iterator, finalise);
+            }
         }
     }
 }

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -19,8 +19,8 @@
 package com.vaticle.typedb.core.common.iterator;
 
 import com.vaticle.typedb.common.collection.Either;
-import com.vaticle.typedb.core.common.iterator.sorted.BaseSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.BaseSeekableIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.BaseSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.ConsumeHandledSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.DistinctSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FilteredSortedIterator;
@@ -144,10 +144,28 @@ public class Iterators {
             return new MappedSortedIterator<>(order, iterator, mappingFn);
         }
 
+        @SafeVarargs
+        public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> merge(SortedIterator<T, ORDER> iterator, SortedIterator<T, ORDER>... iterators) {
+            return new MergeMappedIterator<>(iterator.order(), iterate(list(list(iterators), iterator)), e -> e);
+        }
+
+        public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> merge(ORDER order, FunctionalIterator<SortedIterator<T, ORDER>> iterators) {
+            return new MergeMappedIterator<>(order, iterators, e -> e);
+        }
+
+        public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> onConsume(SortedIterator<T, ORDER> iterator, Runnable onConsume) {
+            return new ConsumeHandledSortedIterator<>(iterator, onConsume);
+        }
+
+        public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> onFinalise(SortedIterator<T, ORDER> iterator,
+                                                                                                                 Runnable finalise) {
+            return new FinaliseSortedIterator<>(iterator, finalise);
+        }
+
         public static class Seekable {
 
             public static <T extends Comparable<T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
-                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
+                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<>());
             }
 
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -107,11 +107,6 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     }
 
     @Override
-    public SortedIterator<T, ORDER> onFinalise(Runnable function) {
-        return new FinaliseSortedIterator<>(this, function);
-    }
-
-    @Override
     public FunctionalIterator<T> offset(long offset) {
         return new OffsetIterator<>(this, offset);
     }
@@ -256,8 +251,13 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     }
 
     @Override
-    public FunctionalIterator<T> onConsumed(Runnable function) {
-        return new ConsumeHandledIterator<>(this, function);
+    public SortedIterator<T, ORDER> onConsumed(Runnable function) {
+        return new ConsumeHandledSortedIterator<>(this, function);
+    }
+
+    @Override
+    public SortedIterator<T, ORDER> onFinalised(Runnable function) {
+        return new FinaliseSortedIterator<>(this, function);
     }
 
     @Override

--- a/common/iterator/sorted/BaseSeekableIterator.java
+++ b/common/iterator/sorted/BaseSeekableIterator.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 
-public class BasedSeekableIterator<T extends Comparable<? super T>, ORDER extends Order>
+public class BaseSeekableIterator<T extends Comparable<? super T>, ORDER extends Order>
         extends AbstractSortedIterator<T, ORDER>
         implements SortedIterator.Seekable<T, ORDER> {
 
@@ -39,7 +39,7 @@ public class BasedSeekableIterator<T extends Comparable<? super T>, ORDER extend
     private T next;
     private T last;
 
-    public BasedSeekableIterator(ORDER order, NavigableSet<T> source) {
+    public BaseSeekableIterator(ORDER order, NavigableSet<T> source) {
         super(order);
         this.source = source;
         this.iterator = order.iterateOrdered(source);
@@ -80,24 +80,34 @@ public class BasedSeekableIterator<T extends Comparable<? super T>, ORDER extend
     }
 
     @Override
-    public final Seekable<T, ORDER> merge(Seekable<T, ORDER> iterator) {
-        return Iterators.Sorted.merge( this, iterator);
+    public final Seekable merge(Seekable iterator) {
+        return Iterators.Sorted.Seekable.merge( this, iterator);
     }
 
     @Override
-    public <U extends Comparable<? super U>, ORD extends Order> Seekable<U, ORD> mapSorted(
+    public <U extends Comparable<? super U>, ORD extends Order> Seekable mapSorted(
             ORD order, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
-        return Iterators.Sorted.mapSorted(order, this, mappingFn, reverseMappingFn);
+        return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
     }
 
     @Override
-    public Seekable<T, ORDER> distinct() {
-        return Iterators.Sorted.distinct(this);
+    public Seekable distinct() {
+        return Iterators.Sorted.Seekable.distinct(this);
     }
 
     @Override
-    public Seekable<T, ORDER> filter(Predicate<T> predicate) {
-        return Iterators.Sorted.filter(this, predicate);
+    public Seekable filter(Predicate<T> predicate) {
+        return Iterators.Sorted.Seekable.filter(this, predicate);
+    }
+
+    @Override
+    public Seekable onConsumed(Runnable function) {
+        return Iterators.Sorted.Seekable.onConsume(this, function);
+    }
+
+    @Override
+    public Seekable onFinalised(Runnable function) {
+        return Iterators.Sorted.Seekable.onFinalise(this, function);
     }
 
     @Override

--- a/common/iterator/sorted/BaseSeekableIterator.java
+++ b/common/iterator/sorted/BaseSeekableIterator.java
@@ -80,33 +80,33 @@ public class BaseSeekableIterator<T extends Comparable<? super T>, ORDER extends
     }
 
     @Override
-    public final Seekable merge(Seekable iterator) {
+    public final Seekable<T, ORDER> merge(Seekable<T, ORDER> iterator) {
         return Iterators.Sorted.Seekable.merge( this, iterator);
     }
 
     @Override
-    public <U extends Comparable<? super U>, ORD extends Order> Seekable mapSorted(
+    public <U extends Comparable<? super U>, ORD extends Order> Seekable<U, ORD> mapSorted(
             ORD order, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
         return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
     }
 
     @Override
-    public Seekable distinct() {
+    public Seekable<T, ORDER> distinct() {
         return Iterators.Sorted.Seekable.distinct(this);
     }
 
     @Override
-    public Seekable filter(Predicate<T> predicate) {
+    public Seekable<T, ORDER> filter(Predicate<T> predicate) {
         return Iterators.Sorted.Seekable.filter(this, predicate);
     }
 
     @Override
-    public Seekable onConsumed(Runnable function) {
+    public Seekable<T, ORDER> onConsumed(Runnable function) {
         return Iterators.Sorted.Seekable.onConsume(this, function);
     }
 
     @Override
-    public Seekable onFinalised(Runnable function) {
+    public Seekable<T, ORDER> onFinalised(Runnable function) {
         return Iterators.Sorted.Seekable.onFinalise(this, function);
     }
 

--- a/common/iterator/sorted/FilteredSortedIterator.java
+++ b/common/iterator/sorted/FilteredSortedIterator.java
@@ -88,23 +88,33 @@ public class FilteredSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public final SortedIterator.Seekable<T, ORDER> merge(SortedIterator.Seekable<T, ORDER> iterator) {
-            return Iterators.Sorted.merge(this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override
         public <U extends Comparable<? super U>, ORD extends Order> SortedIterator.Seekable<U, ORD> mapSorted(
                 ORD order, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
-            return Iterators.Sorted.mapSorted(order, this, mappingFn,  reverseMappingFn);
+            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn,  reverseMappingFn);
         }
 
         @Override
         public SortedIterator.Seekable<T, ORDER> distinct() {
-            return Iterators.Sorted.distinct(this);
+            return Iterators.Sorted.Seekable.distinct(this);
         }
 
         @Override
         public SortedIterator.Seekable<T, ORDER> filter(Predicate<T> predicate) {
-            return Iterators.Sorted.filter(this, predicate);
+            return Iterators.Sorted.Seekable.filter(this, predicate);
+        }
+
+        @Override
+        public SortedIterator.Seekable<T, ORDER> onConsumed(Runnable function) {
+            return Iterators.Sorted.Seekable.onConsume(this, function);
+        }
+
+        @Override
+        public SortedIterator.Seekable<T, ORDER> onFinalised(Runnable function) {
+            return Iterators.Sorted.Seekable.onFinalise(this, function);
         }
     }
 }

--- a/common/iterator/sorted/FinaliseSortedIterator.java
+++ b/common/iterator/sorted/FinaliseSortedIterator.java
@@ -34,7 +34,7 @@ public class FinaliseSortedIterator<T extends Comparable<? super T>, ORDER exten
     final ITER iterator;
     T last;
 
-    FinaliseSortedIterator(ITER iterator, Runnable function) {
+    public FinaliseSortedIterator(ITER iterator, Runnable function) {
         super(iterator.order());
         this.iterator = iterator;
         this.function = function;

--- a/common/iterator/sorted/FinaliseSortedIterator.java
+++ b/common/iterator/sorted/FinaliseSortedIterator.java
@@ -83,23 +83,33 @@ public class FinaliseSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public final SortedIterator.Seekable<T, ORDER> merge(SortedIterator.Seekable<T, ORDER> iterator) {
-            return Iterators.Sorted.merge(this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override
         public <U extends Comparable<? super U>, ORD extends Order> SortedIterator.Seekable<U, ORD> mapSorted(
                 ORD order, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
-            return Iterators.Sorted.mapSorted(order, this, mappingFn, reverseMappingFn);
+            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
         }
 
         @Override
         public SortedIterator.Seekable<T, ORDER> distinct() {
-            return Iterators.Sorted.distinct(this);
+            return Iterators.Sorted.Seekable.distinct(this);
         }
 
         @Override
         public SortedIterator.Seekable<T, ORDER> filter(Predicate<T> predicate) {
-            return Iterators.Sorted.filter(this, predicate);
+            return Iterators.Sorted.Seekable.filter(this, predicate);
+        }
+
+        @Override
+        public SortedIterator.Seekable<T, ORDER> onConsumed(Runnable function) {
+            return Iterators.Sorted.Seekable.onConsume(this, function);
+        }
+
+        @Override
+        public SortedIterator.Seekable<T, ORDER> onFinalised(Runnable function) {
+            return Iterators.Sorted.Seekable.onFinalise(this, function);
         }
     }
 }

--- a/common/iterator/sorted/MappedSortedIterator.java
+++ b/common/iterator/sorted/MappedSortedIterator.java
@@ -135,23 +135,33 @@ public class MappedSortedIterator<
 
         @Override
         public final SortedIterator.Seekable<U, ORDER> merge(SortedIterator.Seekable<U, ORDER> iterator) {
-            return Iterators.Sorted.merge(this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override
         public <V extends Comparable<? super V>, ORD extends Order> SortedIterator.Seekable<V, ORD> mapSorted(
                 ORD order, Function<U, V> mappingFn, Function<V, U> reverseMappingFn) {
-            return Iterators.Sorted.mapSorted(order, this, mappingFn, reverseMappingFn);
+            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
         }
 
         @Override
         public SortedIterator.Seekable<U, ORDER> distinct() {
-            return Iterators.Sorted.distinct(this);
+            return Iterators.Sorted.Seekable.distinct(this);
         }
 
         @Override
         public SortedIterator.Seekable<U, ORDER> filter(Predicate<U> predicate) {
-            return Iterators.Sorted.filter(this, predicate);
+            return Iterators.Sorted.Seekable.filter(this, predicate);
+        }
+
+        @Override
+        public SortedIterator.Seekable<U, ORDER> onConsumed(Runnable function) {
+            return Iterators.Sorted.Seekable.onConsume(this, function);
+        }
+
+        @Override
+        public SortedIterator.Seekable<U, ORDER> onFinalised(Runnable function) {
+            return Iterators.Sorted.Seekable.onFinalise(this, function);
         }
     }
 }

--- a/common/iterator/sorted/MergeMappedIterator.java
+++ b/common/iterator/sorted/MergeMappedIterator.java
@@ -45,7 +45,7 @@ public class MergeMappedIterator<T, U extends Comparable<? super U>, ORDER exten
 
     enum State {INIT, NOT_READY, FETCHED, COMPLETED}
 
-    MergeMappedIterator(ORDER order, FunctionalIterator<T> iterator, Function<T, ITER> mappingFn) {
+    public MergeMappedIterator(ORDER order, FunctionalIterator<T> iterator, Function<T, ITER> mappingFn) {
         super(order);
         this.iterator = iterator;
         this.mappingFn = mappingFn;

--- a/common/iterator/sorted/MergeMappedIterator.java
+++ b/common/iterator/sorted/MergeMappedIterator.java
@@ -160,23 +160,33 @@ public class MergeMappedIterator<T, U extends Comparable<? super U>, ORDER exten
 
         @Override
         public final SortedIterator.Seekable<U, ORDER> merge(SortedIterator.Seekable<U, ORDER> iterator) {
-            return Iterators.Sorted.merge(this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override
         public <V extends Comparable<? super V>, ORD extends Order> SortedIterator.Seekable<V, ORD> mapSorted(
                 ORD order, Function<U, V> mappingFn, Function<V, U> reverseMappingFn) {
-            return Iterators.Sorted.mapSorted(order, this, mappingFn, reverseMappingFn);
+            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
         }
 
         @Override
         public SortedIterator.Seekable<U, ORDER> distinct() {
-            return Iterators.Sorted.distinct(this);
+            return Iterators.Sorted.Seekable.distinct(this);
         }
 
         @Override
         public SortedIterator.Seekable<U, ORDER> filter(Predicate<U> predicate) {
-            return Iterators.Sorted.filter(this, predicate);
+            return Iterators.Sorted.Seekable.filter(this, predicate);
+        }
+
+        @Override
+        public SortedIterator.Seekable<U, ORDER> onConsumed(Runnable function) {
+            return Iterators.Sorted.Seekable.onConsume(this, function);
+        }
+
+        @Override
+        public SortedIterator.Seekable<U, ORDER> onFinalised(Runnable function) {
+            return Iterators.Sorted.Seekable.onFinalise(this, function);
         }
     }
 }

--- a/common/iterator/sorted/SortedIterator.java
+++ b/common/iterator/sorted/SortedIterator.java
@@ -101,6 +101,12 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends S
 
     <U extends Comparable<? super U>, ORD extends Order> SortedIterator<U, ORD> mapSorted(ORD order, Function<T, U> mappingFn);
 
+    @Override
+    SortedIterator<T, ORDER> onConsumed(Runnable function);
+
+    @Override
+    SortedIterator<T, ORDER> onFinalised(Runnable function);
+
     interface Seekable<T extends Comparable<? super T>, ORDER extends Order> extends SortedIterator<T, ORDER> {
 
         void seek(T target);
@@ -116,5 +122,11 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends S
         <U extends Comparable<? super U>, ORD extends Order> Seekable<U, ORD> mapSorted(ORD order,
                                                                                         Function<T, U> mappingFn,
                                                                                         Function<U, T> reverseMappingFn);
+
+        @Override
+        Seekable<T, ORDER> onConsumed(Runnable function);
+
+        @Override
+        Seekable<T, ORDER> onFinalised(Runnable function);
     }
 }

--- a/database/RocksIterator.java
+++ b/database/RocksIterator.java
@@ -151,28 +151,33 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
     @Override
     public final Seekable<KeyValue<T, ByteArray>, ORDER> merge(
             Seekable<KeyValue<T, ByteArray>, ORDER> iterator) {
-        return Iterators.Sorted.merge(this, iterator);
+        return Iterators.Sorted.Seekable.merge(this, iterator);
     }
 
     @Override
     public <V extends Comparable<? super V>, ORD extends Order> Seekable<V, ORD> mapSorted(
             ORD order, Function<KeyValue<T, ByteArray>, V> mappingFn, Function<V, KeyValue<T, ByteArray>> reverseMappingFn) {
-        return Iterators.Sorted.mapSorted(order, this, mappingFn, reverseMappingFn);
+        return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
     }
 
     @Override
     public Seekable<KeyValue<T, ByteArray>, ORDER> distinct() {
-        return Iterators.Sorted.distinct(this);
+        return Iterators.Sorted.Seekable.distinct(this);
     }
 
     @Override
     public Seekable<KeyValue<T, ByteArray>, ORDER> filter(Predicate<KeyValue<T, ByteArray>> predicate) {
-        return Iterators.Sorted.filter(this, predicate);
+        return Iterators.Sorted.Seekable.filter(this, predicate);
     }
 
     @Override
-    public Seekable<KeyValue<T, ByteArray>, ORDER> onFinalise(Runnable finalise) {
-        return Iterators.Sorted.onFinalise(this, finalise);
+    public Seekable<KeyValue<T, ByteArray>, ORDER> onConsumed(Runnable function) {
+        return Iterators.Sorted.Seekable.onConsume(this, function);
+    }
+
+    @Override
+    public Seekable<KeyValue<T, ByteArray>, ORDER> onFinalised(Runnable finalise) {
+        return Iterators.Sorted.Seekable.onFinalise(this, finalise);
     }
 
     static class Ascending<T extends Key> extends RocksIterator<T, Order.Asc> {

--- a/database/RocksStorage.java
+++ b/database/RocksStorage.java
@@ -222,7 +222,7 @@ public abstract class RocksStorage implements Storage {
             else iterator = (RocksIterator<T, ORDER>) new RocksIterator.Descending<>(this, prefix);
             iterators.add(iterator);
             if (!isOpen()) throw TypeDBException.of(RESOURCE_CLOSED); //guard against close() race conditions
-            return iterator.onFinalise(iterator::close);
+            return iterator.onFinalised(iterator::close);
         }
     }
 

--- a/graph/ThingGraph.java
+++ b/graph/ThingGraph.java
@@ -58,7 +58,7 @@ import static com.vaticle.typedb.core.common.collection.ByteArray.encodeLong;
 import static com.vaticle.typedb.core.common.collection.ByteArray.join;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_STRING_SIZE;
-import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSorted;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.tree;

--- a/graph/adjacency/ThingAdjacency.java
+++ b/graph/adjacency/ThingAdjacency.java
@@ -29,9 +29,6 @@ import com.vaticle.typedb.core.graph.iid.IID;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
-import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSorted;
-
 public interface ThingAdjacency {
 
     interface In extends ThingAdjacency {

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -18,23 +18,48 @@
 
 package com.vaticle.typedb.core.graph.adjacency;
 
+import com.vaticle.typedb.core.common.collection.KeyValue;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
 public interface TypeAdjacency {
 
-    /**
-     * Returns an {@code IteratorBuilder} to retrieve vertices of a set of edges.
-     *
-     * This method allows us to traverse the graph, by going from one vertex to
-     * another, that are connected by edges that match the provided {@code encoding}.
-     *
-     * @param encoding the {@code Encoding} to filter the type of edges
-     * @return an {@code IteratorBuilder} to retrieve vertices of a set of edges.
-     */
-    TypeIteratorBuilder edge(Encoding.Edge.Type encoding);
+    interface In extends TypeAdjacency {
+
+        InEdgeIterator edge(Encoding.Edge.Type encoding);
+
+        interface InEdgeIterator {
+
+            Seekable<TypeVertex, Order.Asc> from();
+
+            SortedIterator<TypeVertex, Order.Asc> to();
+
+            FunctionalIterator<TypeVertex> overridden();
+
+            Seekable<KeyValue<TypeVertex, TypeVertex>, Order.Asc> fromAndOverridden();
+        }
+    }
+
+    interface Out extends TypeAdjacency {
+
+        OutEdgeIterator edge(Encoding.Edge.Type encoding);
+
+        interface OutEdgeIterator {
+
+            SortedIterator<TypeVertex, Order.Asc> from();
+
+            Seekable<TypeVertex, Order.Asc> to();
+
+            FunctionalIterator<TypeVertex> overridden();
+
+            Seekable<KeyValue<TypeVertex, TypeVertex>, Order.Asc> toAndOverridden();
+        }
+    }
 
     /**
      * Returns an edge of type {@code encoding} that connects to an {@code adjacent}
@@ -61,39 +86,10 @@ public interface TypeAdjacency {
 
     void deleteAll();
 
+    // TODO delete
     TypeEdge cache(TypeEdge edge);
 
     void remove(TypeEdge edge);
 
     void commit();
-
-    /**
-     * When used in combination with purely retrieving type edges (by infix encoding),
-     * this iterator builder performs safe vertex downcasts at both ends of the edge
-     */
-    class TypeIteratorBuilder {
-
-        private final FunctionalIterator<TypeEdge> edgeIterator;
-
-        public TypeIteratorBuilder(FunctionalIterator<TypeEdge> edgeIterator) {
-            this.edgeIterator = edgeIterator;
-        }
-
-        public FunctionalIterator<TypeVertex> from() {
-            return edgeIterator.map(edge -> edge.from().asType());
-        }
-
-        public FunctionalIterator<TypeVertex> to() {
-            return edgeIterator.map(edge -> edge.to().asType());
-        }
-
-        public FunctionalIterator<TypeVertex> overridden() {
-            return edgeIterator.map(TypeEdge::overridden);
-        }
-
-        public FunctionalIterator<TypeEdge> edge() {
-            return edgeIterator;
-        }
-    }
-
 }

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -33,6 +33,11 @@ public interface TypeAdjacency {
 
         InEdgeIterator edge(Encoding.Edge.Type encoding);
 
+        @Override
+        default boolean isIn() {
+            return true;
+        }
+
         interface InEdgeIterator {
 
             Seekable<TypeVertex, Order.Asc> from();
@@ -49,6 +54,11 @@ public interface TypeAdjacency {
 
         OutEdgeIterator edge(Encoding.Edge.Type encoding);
 
+        @Override
+        default boolean isOut() {
+            return true;
+        }
+
         interface OutEdgeIterator {
 
             SortedIterator<TypeVertex, Order.Asc> from();
@@ -59,6 +69,14 @@ public interface TypeAdjacency {
 
             Seekable<KeyValue<TypeVertex, TypeVertex>, Order.Asc> toAndOverridden();
         }
+    }
+
+    default boolean isIn() {
+        return false;
+    }
+
+    default boolean isOut() {
+        return false;
     }
 
     /**

--- a/graph/adjacency/TypeAdjacency.java
+++ b/graph/adjacency/TypeAdjacency.java
@@ -104,7 +104,6 @@ public interface TypeAdjacency {
 
     void deleteAll();
 
-    // TODO delete
     TypeEdge cache(TypeEdge edge);
 
     void remove(TypeEdge edge);

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -47,9 +47,8 @@ import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Predicate;
 
-import static com.vaticle.typedb.common.collection.Collections.list;
-import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.emptySorted;
-import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSorted;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
@@ -147,7 +146,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
             @Override
             public InEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead) {
-                return new InEdgeIteratorImpl(owner, persistedEdgeIterator(encoding, lookAhead), encoding);
+                return new InEdgeIteratorImpl(owner, encoding, persistedEdgeIterator(encoding, lookAhead));
             }
 
             @Override
@@ -156,7 +155,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                 mergedLookahead[0] = roleType.iid();
                 System.arraycopy(lookAhead, 0, mergedLookahead, 1, lookAhead.length);
                 return new InEdgeIteratorImpl.Optimised(
-                        owner, persistedEdgeIterator(encoding, mergedLookahead), encoding, roleType
+                        owner, encoding, persistedEdgeIterator(encoding, mergedLookahead), roleType
                 );
             }
 
@@ -174,7 +173,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
             @Override
             public OutEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookAhead) {
-                return new OutEdgeIteratorImpl(owner, persistedEdgeIterator(encoding, lookAhead), encoding);
+                return new OutEdgeIteratorImpl(owner, encoding, persistedEdgeIterator(encoding, lookAhead));
             }
 
             @Override
@@ -183,7 +182,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                 mergedLookahead[0] = roleType.iid();
                 System.arraycopy(lookAhead, 0, mergedLookahead, 1, lookAhead.length);
                 return new OutEdgeIteratorImpl.Optimised(
-                        owner, persistedEdgeIterator(encoding, mergedLookahead), encoding, roleType
+                        owner, encoding, persistedEdgeIterator(encoding, mergedLookahead), roleType
                 );
             }
 
@@ -408,7 +407,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
                 @Override
                 public InEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookahead) {
-                    return new InEdgeIteratorImpl(owner, bufferedEdgeIterator(encoding, lookahead), encoding);
+                    return new InEdgeIteratorImpl(owner, encoding, bufferedEdgeIterator(encoding, lookahead));
                 }
 
                 @Override
@@ -418,7 +417,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                     mergedLookahead[0] = roleType.iid();
                     System.arraycopy(lookahead, 0, mergedLookahead, 1, lookahead.length);
                     return new InEdgeIteratorImpl.Optimised(
-                            owner, bufferedEdgeIterator(ROLEPLAYER, mergedLookahead), encoding, roleType
+                            owner, encoding, bufferedEdgeIterator(ROLEPLAYER, mergedLookahead), roleType
                     );
                 }
             }
@@ -436,7 +435,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
                 @Override
                 public OutEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookahead) {
-                    return new OutEdgeIteratorImpl(owner, bufferedEdgeIterator(encoding, lookahead), encoding);
+                    return new OutEdgeIteratorImpl(owner, encoding, bufferedEdgeIterator(encoding, lookahead));
                 }
 
                 @Override
@@ -446,7 +445,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                     mergedLookahead[0] = roleType.iid();
                     System.arraycopy(lookahead, 0, mergedLookahead, 1, lookahead.length);
                     return new OutEdgeIteratorImpl.Optimised(
-                            owner, bufferedEdgeIterator(ROLEPLAYER, mergedLookahead), encoding, roleType
+                            owner, encoding, bufferedEdgeIterator(ROLEPLAYER, mergedLookahead), roleType
                     );
                 }
 
@@ -526,7 +525,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
                 @Override
                 public InEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookahead) {
-                    return new InEdgeIteratorImpl(owner, edgeIterator(encoding, lookahead), encoding);
+                    return new InEdgeIteratorImpl(owner, encoding, edgeIterator(encoding, lookahead));
                 }
 
                 @Override
@@ -535,7 +534,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                     IID[] mergedLookahead = new IID[1 + lookahead.length];
                     mergedLookahead[0] = roleType.iid();
                     System.arraycopy(lookahead, 0, mergedLookahead, 1, lookahead.length);
-                    return new InEdgeIteratorImpl.Optimised(owner, edgeIterator(ROLEPLAYER, mergedLookahead), encoding, roleType);
+                    return new InEdgeIteratorImpl.Optimised(owner, encoding, edgeIterator(ROLEPLAYER, mergedLookahead), roleType);
 
                 }
             }
@@ -553,7 +552,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
 
                 @Override
                 public OutEdgeIterator edge(Encoding.Edge.Thing.Base encoding, IID... lookahead) {
-                    return new OutEdgeIteratorImpl(owner, edgeIterator(encoding, lookahead), encoding);
+                    return new OutEdgeIteratorImpl(owner, encoding, edgeIterator(encoding, lookahead));
                 }
 
                 @Override
@@ -562,7 +561,7 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                     IID[] mergedLookahead = new IID[1 + lookahead.length];
                     mergedLookahead[0] = roleType.iid();
                     System.arraycopy(lookahead, 0, mergedLookahead, 1, lookahead.length);
-                    return new OutEdgeIteratorImpl.Optimised(owner, edgeIterator(ROLEPLAYER, mergedLookahead), encoding, roleType);
+                    return new OutEdgeIteratorImpl.Optimised(owner, encoding, edgeIterator(ROLEPLAYER, mergedLookahead), roleType);
                 }
             }
         }

--- a/graph/adjacency/impl/ThingEdgeIterator.java
+++ b/graph/adjacency/impl/ThingEdgeIterator.java
@@ -41,7 +41,7 @@ public abstract class ThingEdgeIterator {
         final Seekable<ThingEdge.View.Backward, Order.Asc> edges;
         final Encoding.Edge.Thing encoding;
 
-        InEdgeIteratorImpl(ThingVertex owner, Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Backward, Order.Asc> edges) {
+        InEdgeIteratorImpl(Seekable<ThingEdge.View.Backward, Order.Asc> edges, ThingVertex owner, Encoding.Edge.Thing encoding) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -65,9 +65,9 @@ public abstract class ThingEdgeIterator {
 
             private final TypeVertex optimisedType;
 
-            public Optimised(ThingVertex owner, Encoding.Edge.Thing encoding,
-                             Seekable<ThingEdge.View.Backward, Order.Asc> edges, TypeVertex optimisedType) {
-                super(owner, encoding, edges);
+            public Optimised(Seekable<ThingEdge.View.Backward, Order.Asc> edges, ThingVertex owner, Encoding.Edge.Thing encoding,
+                             TypeVertex optimisedType) {
+                super(edges, owner, encoding);
                 this.optimisedType = optimisedType;
             }
 
@@ -93,7 +93,7 @@ public abstract class ThingEdgeIterator {
         final Seekable<ThingEdge.View.Forward, Order.Asc> edges;
         final Encoding.Edge.Thing encoding;
 
-        OutEdgeIteratorImpl(ThingVertex owner, Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Forward, Order.Asc> edges) {
+        OutEdgeIteratorImpl(Seekable<ThingEdge.View.Forward, Order.Asc> edges, ThingVertex owner, Encoding.Edge.Thing encoding) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -117,10 +117,10 @@ public abstract class ThingEdgeIterator {
 
             private final TypeVertex optimisedType;
 
-            Optimised(ThingVertex owner,
-                      Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Forward, Order.Asc> edges,
+            Optimised(Seekable<ThingEdge.View.Forward, Order.Asc> edges, ThingVertex owner,
+                      Encoding.Edge.Thing encoding,
                       TypeVertex optimisedType) {
-                super(owner, encoding, edges);
+                super(edges, owner, encoding);
                 this.optimisedType = optimisedType;
             }
 

--- a/graph/adjacency/impl/ThingEdgeIterator.java
+++ b/graph/adjacency/impl/ThingEdgeIterator.java
@@ -41,7 +41,7 @@ public abstract class ThingEdgeIterator {
         final Seekable<ThingEdge.View.Backward, Order.Asc> edges;
         final Encoding.Edge.Thing encoding;
 
-        InEdgeIteratorImpl(ThingVertex owner, Seekable<ThingEdge.View.Backward, Order.Asc> edges, Encoding.Edge.Thing encoding) {
+        InEdgeIteratorImpl(ThingVertex owner, Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Backward, Order.Asc> edges) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -65,11 +65,9 @@ public abstract class ThingEdgeIterator {
 
             private final TypeVertex optimisedType;
 
-            public Optimised(ThingVertex owner,
-                             Seekable<ThingEdge.View.Backward, Order.Asc> edges,
-                             Encoding.Edge.Thing encoding,
-                             TypeVertex optimisedType) {
-                super(owner, edges, encoding);
+            public Optimised(ThingVertex owner, Encoding.Edge.Thing encoding,
+                             Seekable<ThingEdge.View.Backward, Order.Asc> edges, TypeVertex optimisedType) {
+                super(owner, encoding, edges);
                 this.optimisedType = optimisedType;
             }
 
@@ -95,7 +93,7 @@ public abstract class ThingEdgeIterator {
         final Seekable<ThingEdge.View.Forward, Order.Asc> edges;
         final Encoding.Edge.Thing encoding;
 
-        OutEdgeIteratorImpl(ThingVertex owner, Seekable<ThingEdge.View.Forward, Order.Asc> edges, Encoding.Edge.Thing encoding) {
+        OutEdgeIteratorImpl(ThingVertex owner, Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Forward, Order.Asc> edges) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -120,10 +118,9 @@ public abstract class ThingEdgeIterator {
             private final TypeVertex optimisedType;
 
             Optimised(ThingVertex owner,
-                      Seekable<ThingEdge.View.Forward, Order.Asc> edges,
-                      Encoding.Edge.Thing encoding,
+                      Encoding.Edge.Thing encoding, Seekable<ThingEdge.View.Forward, Order.Asc> edges,
                       TypeVertex optimisedType) {
-                super(owner, edges, encoding);
+                super(owner, encoding, edges);
                 this.optimisedType = optimisedType;
             }
 

--- a/graph/adjacency/impl/ThingEdgeIterator.java
+++ b/graph/adjacency/impl/ThingEdgeIterator.java
@@ -38,22 +38,22 @@ public abstract class ThingEdgeIterator {
     static class InEdgeIteratorImpl implements ThingAdjacency.In.InEdgeIterator {
 
         final ThingVertex owner;
-        final Seekable<ThingEdge.View.Backward, SortedIterator.Order.Asc> edges;
+        final Seekable<ThingEdge.View.Backward, Order.Asc> edges;
         final Encoding.Edge.Thing encoding;
 
-        InEdgeIteratorImpl(ThingVertex owner, Seekable<ThingEdge.View.Backward, SortedIterator.Order.Asc> edges, Encoding.Edge.Thing encoding) {
+        InEdgeIteratorImpl(ThingVertex owner, Seekable<ThingEdge.View.Backward, Order.Asc> edges, Encoding.Edge.Thing encoding) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
         }
 
         @Override
-        public Seekable<ThingVertex, SortedIterator.Order.Asc> from() {
+        public Seekable<ThingVertex, Order.Asc> from() {
             return edges.mapSorted(ASC, view -> view.edge().from(), this::targetEdge);
         }
 
         @Override
-        public SortedIterator<ThingVertex, SortedIterator.Order.Asc> to() {
+        public SortedIterator<ThingVertex, Order.Asc> to() {
             return iterateSorted(ASC, list(owner));
         }
 
@@ -66,7 +66,7 @@ public abstract class ThingEdgeIterator {
             private final TypeVertex optimisedType;
 
             public Optimised(ThingVertex owner,
-                             Seekable<ThingEdge.View.Backward, SortedIterator.Order.Asc> edges,
+                             Seekable<ThingEdge.View.Backward, Order.Asc> edges,
                              Encoding.Edge.Thing encoding,
                              TypeVertex optimisedType) {
                 super(owner, edges, encoding);
@@ -74,7 +74,7 @@ public abstract class ThingEdgeIterator {
             }
 
             @Override
-            public Seekable<KeyValue<ThingVertex, ThingVertex>, SortedIterator.Order.Asc> fromAndOptimised() {
+            public Seekable<KeyValue<ThingVertex, ThingVertex>, Order.Asc> fromAndOptimised() {
                 return edges.mapSorted(
                         ASC,
                         edgeView -> KeyValue.of(edgeView.edge().from(), edgeView.edge().optimised().get()),

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -20,11 +20,14 @@ package com.vaticle.typedb.core.graph.adjacency.impl;
 
 import com.vaticle.typedb.common.collection.ConcurrentSet;
 import com.vaticle.typedb.core.common.collection.ByteArray;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.collection.KeyValue;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.graph.adjacency.TypeAdjacency;
+import com.vaticle.typedb.core.graph.adjacency.impl.TypeEdgeIterator.InEdgeIteratorImpl;
+import com.vaticle.typedb.core.graph.adjacency.impl.TypeEdgeIterator.OutEdgeIteratorImpl;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.common.Storage.Key;
-import com.vaticle.typedb.core.graph.edge.Edge;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.edge.impl.TypeEdgeImpl;
 import com.vaticle.typedb.core.graph.iid.EdgeViewIID;
@@ -35,23 +38,26 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Predicate;
 
-import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 
-public abstract class TypeAdjacencyImpl implements TypeAdjacency {
+public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>> implements TypeAdjacency {
 
     final TypeVertex owner;
-    final Encoding.Direction.Adjacency direction;
-    final ConcurrentMap<Encoding.Edge.Type, ConcurrentSet<TypeEdge>> edges;
+    final ConcurrentMap<Encoding.Edge.Type, ConcurrentSkipListSet<EDGE_VIEW>> edges;
 
-    TypeAdjacencyImpl(TypeVertex owner, Encoding.Direction.Adjacency direction) {
+    TypeAdjacencyImpl(TypeVertex owner) {
         this.owner = owner;
-        this.direction = direction;
         this.edges = new ConcurrentHashMap<>();
     }
+
+    abstract EDGE_VIEW getView(TypeEdge edge);
 
     private void putNonRecursive(TypeEdge edge) {
         assert !owner.isDeleted();
@@ -62,26 +68,26 @@ public abstract class TypeAdjacencyImpl implements TypeAdjacency {
     @Override
     public TypeEdge put(Encoding.Edge.Type encoding, TypeVertex adjacent) {
         assert !owner.isDeleted();
-        TypeVertex from = direction.isOut() ? owner : adjacent;
-        TypeVertex to = direction.isOut() ? adjacent : owner;
+        TypeVertex from = isOut() ? owner : adjacent;
+        TypeVertex to = isOut() ? adjacent : owner;
         TypeEdgeImpl edge = new TypeEdgeImpl.Buffered(encoding, from, to);
-        edges.computeIfAbsent(encoding, e -> new ConcurrentSet<>()).add(edge);
-        if (direction.isOut()) ((TypeAdjacencyImpl) to.ins()).putNonRecursive(edge);
-        else ((TypeAdjacencyImpl) from.outs()).putNonRecursive(edge);
+        edges.computeIfAbsent(encoding, e -> new ConcurrentSkipListSet<>()).add(getView(edge));
+        if (isOut()) ((TypeAdjacencyImpl<?>) to.ins()).putNonRecursive(edge);
+        else ((TypeAdjacencyImpl<?>) from.outs()).putNonRecursive(edge);
         owner.setModified();
         return edge;
     }
 
     @Override
     public TypeEdge cache(TypeEdge edge) {
-        edges.computeIfAbsent(edge.encoding(), e -> new ConcurrentSet<>()).add(edge);
+        edges.computeIfAbsent(edge.encoding(), e -> new ConcurrentSkipListSet<>()).add(getView(edge));
         return edge;
     }
 
     @Override
     public void remove(TypeEdge edge) {
         if (edges.containsKey(edge.encoding())) {
-            edges.get(edge.encoding()).remove(edge);
+            edges.get(edge.encoding()).remove(getView(edge));
             owner.setModified();
         }
     }
@@ -93,52 +99,126 @@ public abstract class TypeAdjacencyImpl implements TypeAdjacency {
 
     @Override
     public void commit() {
-        edges.values().forEach(set -> set.forEach(Edge::commit));
+        edges.values().forEach(set -> set.forEach(view -> view.edge().commit()));
     }
 
-    public static class Buffered extends TypeAdjacencyImpl implements TypeAdjacency {
+    static abstract class Buffered<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
+            extends TypeAdjacencyImpl<EDGE_VIEW> implements TypeAdjacency {
 
-        public Buffered(TypeVertex owner, Encoding.Direction.Adjacency direction) {
-            super(owner, direction);
+        Buffered(TypeVertex owner) {
+            super(owner);
         }
 
-        @Override
-        public TypeIteratorBuilder edge(Encoding.Edge.Type encoding) {
-            ConcurrentSet<TypeEdge> t = edges.get(encoding);
-            if (t != null) return new TypeIteratorBuilder(iterate(t.iterator()));
-            return new TypeIteratorBuilder(empty());
-        }
+        static class In extends Buffered<TypeEdge.View.Backward> implements TypeAdjacency.In {
 
-        @Override
-        public TypeEdge edge(Encoding.Edge.Type encoding, TypeVertex adjacent) {
-            if (edges.containsKey(encoding)) {
-                Predicate<TypeEdge> predicate = direction.isOut()
-                        ? e -> e.to().equals(adjacent)
-                        : e -> e.from().equals(adjacent);
-                return edges.get(encoding).stream().filter(predicate).findAny().orElse(null);
+            In(TypeVertex owner) {
+                super(owner);
             }
-            return null;
+
+            @Override
+            public InEdgeIterator edge(Encoding.Edge.Type encoding) {
+                ConcurrentSkipListSet<TypeEdge.View.Backward> t = edges.get(encoding);
+                if (t != null) return new InEdgeIteratorImpl(owner, encoding, iterateSorted(ASC, t));
+                return new InEdgeIteratorImpl(owner, encoding, emptySorted());
+            }
+
+            @Override
+            public TypeEdge edge(Encoding.Edge.Type encoding, TypeVertex adjacent) {
+                if (edges.containsKey(encoding)) {
+                    return edges.get(encoding).stream().filter(view -> view.edge().from().equals(adjacent))
+                            .findAny().map(TypeEdge.View::edge).orElse(null);
+                }
+                return null;
+            }
+
+            @Override
+            TypeEdge.View.Backward getView(TypeEdge edge) {
+                return edge.getBackward();
+            }
+        }
+
+        static class Out extends Buffered<TypeEdge.View.Forward> implements TypeAdjacency.Out {
+
+            Out(TypeVertex owner) {
+                super(owner);
+            }
+
+            @Override
+            public OutEdgeIterator edge(Encoding.Edge.Type encoding) {
+                ConcurrentSkipListSet<TypeEdge.View.Forward> t = edges.get(encoding);
+                if (t != null) return new OutEdgeIteratorImpl(owner, encoding, iterateSorted(ASC, t));
+                return new OutEdgeIteratorImpl(owner, encoding, emptySorted());
+            }
+
+            @Override
+            TypeEdge.View.Forward getView(TypeEdge edge) {
+                return edge.getForward();
+            }
+
+            @Override
+            public TypeEdge edge(Encoding.Edge.Type encoding, TypeVertex adjacent) {
+                if (edges.containsKey(encoding)) {
+                    return edges.get(encoding).stream().filter(view -> view.edge().to().equals(adjacent))
+                            .findAny().map(TypeEdge.View::edge).orElse(null);
+                }
+                return null;
+            }
         }
 
         @Override
         public void delete(Encoding.Edge.Type encoding) {
-            if (edges.containsKey(encoding)) edges.get(encoding).forEach(Edge::delete);
+            if (edges.containsKey(encoding)) edges.get(encoding).forEach(view -> view.edge().delete());
         }
     }
 
-    public static class Persisted extends TypeAdjacencyImpl implements TypeAdjacency {
+    static abstract class Persisted<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
+            extends TypeAdjacencyImpl<EDGE_VIEW> implements TypeAdjacency {
 
         private final ConcurrentSet<Encoding.Edge.Type> fetched;
         private final boolean isReadOnly;
 
-        public Persisted(TypeVertex owner, Encoding.Direction.Adjacency direction) {
-            super(owner, direction);
+        Persisted(TypeVertex owner) {
+            super(owner);
             fetched = new ConcurrentSet<>();
             isReadOnly = owner.graph().isReadOnly();
         }
 
+        static class In extends Persisted<TypeEdge.View.Backward> implements TypeAdjacency.In {
+
+            In(TypeVertex owner) {
+                super(owner);
+            }
+
+            @Override
+            TypeEdge.View.Backward getView(TypeEdge edge) {
+                return edge.getBackward();
+            }
+
+            @Override
+            public InEdgeIterator edge(Encoding.Edge.Type encoding) {
+                return null;
+            }
+        }
+
+        static class Out extends Persisted<TypeEdge.View.Forward> implements TypeAdjacency.Out {
+
+            Out(TypeVertex owner) {
+                super(owner);
+            }
+
+            @Override
+            TypeEdge.View.Forward getView(TypeEdge edge) {
+                return edge.getForward();
+            }
+
+            @Override
+            public OutEdgeIterator edge(Encoding.Edge.Type encoding) {
+                return null;
+            }
+        }
+
         private EdgeViewIID.Type edgeIID(Encoding.Edge.Type encoding, TypeVertex adjacent) {
-            return EdgeViewIID.Type.of(owner.iid(), direction.isOut() ? encoding.forward() : encoding.backward(), adjacent.iid());
+            return EdgeViewIID.Type.of(owner.iid(), isOut() ? encoding.forward() : encoding.backward(), adjacent.iid());
         }
 
         private TypeEdge newPersistedEdge(EdgeViewIID.Type edge, ByteArray value) {
@@ -146,36 +226,36 @@ public abstract class TypeAdjacencyImpl implements TypeAdjacency {
             return new TypeEdgeImpl.Persisted(owner.graph(), edge, overridden);
         }
 
-        private FunctionalIterator<TypeEdge> edgeIterator(Encoding.Edge.Type encoding) {
-            ConcurrentSet<TypeEdge> bufferedEdges;
+        private Seekable<EDGE_VIEW, Order.Asc> edgeIterator(Encoding.Edge.Type encoding) {
+            ConcurrentSkipListSet<EDGE_VIEW> bufferedEdges;
             if (isReadOnly && fetched.contains(encoding)) {
-                return (bufferedEdges = edges.get(encoding)) != null ? iterate(bufferedEdges) : empty();
+                return (bufferedEdges = edges.get(encoding)) != null ? iterateSorted(ASC, bufferedEdges) : emptySorted();
             }
 
             Key.Prefix<EdgeViewIID.Type> prefix = EdgeViewIID.Type.prefix(
-                    owner.iid(), InfixIID.Type.of(direction.isOut() ? encoding.forward() : encoding.backward())
+                    owner.iid(), InfixIID.Type.of(isOut() ? encoding.forward() : encoding.backward())
             );
-            FunctionalIterator<TypeEdge> storageIterator = owner.graph().storage().iterate(prefix)
-                    .map(kv -> cache(newPersistedEdge(EdgeViewIID.Type.of(kv.key().bytes()), kv.value())));
+            Seekable<EDGE_VIEW, Order.Asc> storageIterator = owner.graph().storage().iterate(prefix, ASC)
+                    .mapSorted(
+                            ASC,
+                            kv -> getView(cache(newPersistedEdge(EdgeViewIID.Type.of(kv.key().bytes()), kv.value()))),
+                            edgeView -> KeyValue.of(edgeView.iid(), ByteArray.empty())
+                    );
             if (isReadOnly) storageIterator = storageIterator.onConsumed(() -> fetched.add(encoding));
             if ((bufferedEdges = edges.get(encoding)) == null) return storageIterator;
-            else return link(bufferedEdges.iterator(), storageIterator).distinct();
+            else return iterateSorted(ASC, bufferedEdges).merge(storageIterator).distinct();
         }
 
-        @Override
-        public TypeIteratorBuilder edge(Encoding.Edge.Type encoding) {
-            return new TypeIteratorBuilder(edgeIterator(encoding));
-        }
 
         @Override
         public TypeEdge edge(Encoding.Edge.Type encoding, TypeVertex adjacent) {
-            Optional<TypeEdge> container;
-            Predicate<TypeEdge> predicate = direction.isOut()
+            Predicate<TypeEdge> predicate = isOut()
                     ? e -> e.to().equals(adjacent)
                     : e -> e.from().equals(adjacent);
 
-            if (edges.containsKey(encoding) &&
-                    (container = edges.get(encoding).stream().filter(predicate).findAny()).isPresent()) {
+            Optional<TypeEdge> container = edges.get(encoding).stream().filter(view -> predicate.test(view.edge()))
+                    .findAny().map(TypeEdge.View::edge);
+            if (edges.containsKey(encoding) && container.isPresent()) {
                 return container.get();
             } else {
                 EdgeViewIID.Type edgeIID = edgeIID(encoding, adjacent);
@@ -184,13 +264,12 @@ public abstract class TypeAdjacencyImpl implements TypeAdjacency {
                     return cache(newPersistedEdge(edgeIID, overriddenIID));
                 }
             }
-
             return null;
         }
 
         @Override
         public void delete(Encoding.Edge.Type encoding) {
-            edgeIterator(encoding).forEachRemaining(Edge::delete);
+            edgeIterator(encoding).forEachRemaining(view -> view.edge().delete());
         }
 
         @Override

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -221,8 +221,8 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             return EdgeViewIID.Type.of(owner.iid(), isOut() ? encoding.forward() : encoding.backward(), adjacent.iid());
         }
 
-        private TypeEdge newPersistedEdge(EdgeViewIID.Type edge, ByteArray value) {
-            VertexIID.Type overridden = ((value.isEmpty()) ? null : VertexIID.Type.of(value));
+        private TypeEdge newPersistedEdge(EdgeViewIID.Type edge, ByteArray overriddenBytes) {
+            VertexIID.Type overridden = ((overriddenBytes.isEmpty()) ? null : VertexIID.Type.of(overriddenBytes));
             return new TypeEdgeImpl.Persisted(owner.graph(), edge, overridden);
         }
 
@@ -269,11 +269,6 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
         @Override
         public void delete(Encoding.Edge.Type encoding) {
             edgeIterator(encoding).forEachRemaining(view -> view.edge().delete());
-        }
-
-        @Override
-        public void deleteAll() {
-            for (Encoding.Edge.Type type : Encoding.Edge.Type.values()) delete(type);
         }
     }
 }

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -118,8 +118,8 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             @Override
             public InEdgeIterator edge(Encoding.Edge.Type encoding) {
                 ConcurrentSkipListSet<TypeEdge.View.Backward> t = edges.get(encoding);
-                if (t != null) return new InEdgeIteratorImpl(owner, encoding, iterateSorted(ASC, t));
-                return new InEdgeIteratorImpl(owner, encoding, emptySorted());
+                if (t != null) return new InEdgeIteratorImpl(iterateSorted(ASC, t), owner, encoding);
+                return new InEdgeIteratorImpl(emptySorted(), owner, encoding);
             }
 
             @Override
@@ -146,8 +146,8 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             @Override
             public OutEdgeIterator edge(Encoding.Edge.Type encoding) {
                 ConcurrentSkipListSet<TypeEdge.View.Forward> t = edges.get(encoding);
-                if (t != null) return new OutEdgeIteratorImpl(owner, encoding, iterateSorted(ASC, t));
-                return new OutEdgeIteratorImpl(owner, encoding, emptySorted());
+                if (t != null) return new OutEdgeIteratorImpl(iterateSorted(ASC, t), owner, encoding);
+                return new OutEdgeIteratorImpl(emptySorted(), owner, encoding);
             }
 
             @Override
@@ -196,7 +196,7 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
 
             @Override
             public InEdgeIterator edge(Encoding.Edge.Type encoding) {
-                return new InEdgeIteratorImpl(owner, encoding, edgeIterator(encoding));
+                return new InEdgeIteratorImpl(iterateViews(encoding), owner, encoding);
             }
         }
 
@@ -213,7 +213,7 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
 
             @Override
             public OutEdgeIterator edge(Encoding.Edge.Type encoding) {
-                return new OutEdgeIteratorImpl(owner, encoding, edgeIterator(encoding));
+                return new OutEdgeIteratorImpl(iterateViews(encoding), owner, encoding);
             }
         }
 
@@ -226,7 +226,7 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             return new TypeEdgeImpl.Persisted(owner.graph(), edge, overridden);
         }
 
-        Seekable<EDGE_VIEW, Order.Asc> edgeIterator(Encoding.Edge.Type encoding) {
+        Seekable<EDGE_VIEW, Order.Asc> iterateViews(Encoding.Edge.Type encoding) {
             ConcurrentSkipListSet<EDGE_VIEW> bufferedEdges;
             if (isReadOnly && fetched.contains(encoding)) {
                 return (bufferedEdges = edges.get(encoding)) != null ? iterateSorted(ASC, bufferedEdges) : emptySorted();
@@ -268,7 +268,7 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
 
         @Override
         public void delete(Encoding.Edge.Type encoding) {
-            edgeIterator(encoding).forEachRemaining(view -> view.edge().delete());
+            iterateViews(encoding).forEachRemaining(view -> view.edge().delete());
         }
     }
 }

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -102,16 +102,16 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
         edges.values().forEach(set -> set.forEach(view -> view.edge().commit()));
     }
 
-    static abstract class Buffered<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
+    public static abstract class Buffered<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
             extends TypeAdjacencyImpl<EDGE_VIEW> implements TypeAdjacency {
 
         Buffered(TypeVertex owner) {
             super(owner);
         }
 
-        static class In extends Buffered<TypeEdge.View.Backward> implements TypeAdjacency.In {
+        public static class In extends Buffered<TypeEdge.View.Backward> implements TypeAdjacency.In {
 
-            In(TypeVertex owner) {
+            public In(TypeVertex owner) {
                 super(owner);
             }
 
@@ -137,9 +137,9 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             }
         }
 
-        static class Out extends Buffered<TypeEdge.View.Forward> implements TypeAdjacency.Out {
+        public static class Out extends Buffered<TypeEdge.View.Forward> implements TypeAdjacency.Out {
 
-            Out(TypeVertex owner) {
+            public Out(TypeVertex owner) {
                 super(owner);
             }
 
@@ -171,7 +171,7 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
         }
     }
 
-    static abstract class Persisted<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
+    public static abstract class Persisted<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>>
             extends TypeAdjacencyImpl<EDGE_VIEW> implements TypeAdjacency {
 
         private final ConcurrentSet<Encoding.Edge.Type> fetched;
@@ -183,9 +183,9 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             isReadOnly = owner.graph().isReadOnly();
         }
 
-        static class In extends Persisted<TypeEdge.View.Backward> implements TypeAdjacency.In {
+        public static class In extends Persisted<TypeEdge.View.Backward> implements TypeAdjacency.In {
 
-            In(TypeVertex owner) {
+            public In(TypeVertex owner) {
                 super(owner);
             }
 
@@ -200,9 +200,9 @@ public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIE
             }
         }
 
-        static class Out extends Persisted<TypeEdge.View.Forward> implements TypeAdjacency.Out {
+        public static class Out extends Persisted<TypeEdge.View.Forward> implements TypeAdjacency.Out {
 
-            Out(TypeVertex owner) {
+            public Out(TypeVertex owner) {
                 super(owner);
             }
 

--- a/graph/adjacency/impl/TypeEdgeIterator.java
+++ b/graph/adjacency/impl/TypeEdgeIterator.java
@@ -41,7 +41,7 @@ public abstract class TypeEdgeIterator {
         final Seekable<TypeEdge.View.Backward, Order.Asc> edges;
         final Encoding.Edge.Type encoding;
 
-        InEdgeIteratorImpl(TypeVertex owner, Seekable<TypeEdge.View.Backward, Order.Asc> edges, Encoding.Edge.Type encoding) {
+        InEdgeIteratorImpl(TypeVertex owner, Encoding.Edge.Type encoding, Seekable<TypeEdge.View.Backward, Order.Asc> edges) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -82,7 +82,7 @@ public abstract class TypeEdgeIterator {
         final Seekable<TypeEdge.View.Forward, Order.Asc> edges;
         final Encoding.Edge.Type encoding;
 
-        OutEdgeIteratorImpl(TypeVertex owner, Seekable<TypeEdge.View.Forward, Order.Asc> edges, Encoding.Edge.Type encoding) {
+        OutEdgeIteratorImpl(TypeVertex owner, Encoding.Edge.Type encoding, Seekable<TypeEdge.View.Forward, Order.Asc> edges) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;

--- a/graph/adjacency/impl/TypeEdgeIterator.java
+++ b/graph/adjacency/impl/TypeEdgeIterator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.graph.adjacency.impl;
+
+import com.vaticle.typedb.core.common.collection.KeyValue;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
+import com.vaticle.typedb.core.graph.adjacency.TypeAdjacency;
+import com.vaticle.typedb.core.graph.common.Encoding;
+import com.vaticle.typedb.core.graph.edge.TypeEdge;
+import com.vaticle.typedb.core.graph.edge.impl.TypeEdgeImpl;
+import com.vaticle.typedb.core.graph.vertex.TypeVertex;
+
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSorted;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
+import static java.util.Collections.list;
+
+public abstract class TypeEdgeIterator {
+
+    static class InEdgeIteratorImpl implements TypeAdjacency.In.InEdgeIterator {
+
+        final TypeVertex owner;
+        final Seekable<TypeEdge.View.Backward, Order.Asc> edges;
+        final Encoding.Edge.Type encoding;
+
+        InEdgeIteratorImpl(TypeVertex owner, Seekable<TypeEdge.View.Backward, Order.Asc> edges, Encoding.Edge.Type encoding) {
+            this.owner = owner;
+            this.edges = edges;
+            this.encoding = encoding;
+        }
+
+        @Override
+        public Seekable<TypeVertex, Order.Asc> from() {
+            return edges.mapSorted(ASC, edgeView -> edgeView.edge().from(), this::targetEdge);
+        }
+
+        @Override
+        public SortedIterator<TypeVertex, Order.Asc> to() {
+            return iterateSorted(ASC, list(owner));
+        }
+
+        @Override
+        public FunctionalIterator<TypeVertex> overridden() {
+            return edges.map(edgeView -> edgeView.edge().overridden());
+        }
+
+        @Override
+        public Seekable<KeyValue<TypeVertex, TypeVertex>, Order.Asc> fromAndOverridden() {
+            return edges.mapSorted(
+                    ASC,
+                    edgeView -> KeyValue.of(edgeView.edge().from(), edgeView.edge().overridden()),
+                    fromAndOverridden -> targetEdge(fromAndOverridden.key())
+            );
+        }
+
+        TypeEdge.View.Backward targetEdge(TypeVertex targetFrom) {
+            return new TypeEdgeImpl.Target(encoding, targetFrom, owner).getBackward();
+        }
+    }
+
+    static class OutEdgeIteratorImpl implements TypeAdjacency.Out.OutEdgeIterator {
+
+        final TypeVertex owner;
+        final Seekable<TypeEdge.View.Forward, Order.Asc> edges;
+        final Encoding.Edge.Type encoding;
+
+        OutEdgeIteratorImpl(TypeVertex owner, Seekable<TypeEdge.View.Forward, Order.Asc> edges, Encoding.Edge.Type encoding) {
+            this.owner = owner;
+            this.edges = edges;
+            this.encoding = encoding;
+        }
+
+        @Override
+        public SortedIterator<TypeVertex, Order.Asc> from() {
+            return iterateSorted(ASC, list(owner));
+        }
+
+        @Override
+        public Seekable<TypeVertex, Order.Asc> to() {
+            return edges.mapSorted(ASC, edgeView -> edgeView.edge().to(), this::targetEdge);
+        }
+
+        @Override
+        public FunctionalIterator<TypeVertex> overridden() {
+            return edges.map(edgeView -> edgeView.edge().overridden());
+        }
+
+        @Override
+        public Seekable<KeyValue<TypeVertex, TypeVertex>, Order.Asc> toAndOverridden() {
+            return edges.mapSorted(
+                    ASC,
+                    edgeView -> KeyValue.of(edgeView.edge().to(), edgeView.edge().overridden()),
+                    toAndOverridden -> targetEdge(toAndOverridden.key())
+            );
+        }
+
+        TypeEdge.View.Forward targetEdge(TypeVertex targetTo) {
+            return new TypeEdgeImpl.Target(encoding, owner, targetTo).getForward();
+        }
+    }
+}

--- a/graph/adjacency/impl/TypeEdgeIterator.java
+++ b/graph/adjacency/impl/TypeEdgeIterator.java
@@ -29,9 +29,9 @@ import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.edge.impl.TypeEdgeImpl;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
-import static java.util.Collections.list;
 
 public abstract class TypeEdgeIterator {
 

--- a/graph/adjacency/impl/TypeEdgeIterator.java
+++ b/graph/adjacency/impl/TypeEdgeIterator.java
@@ -41,7 +41,7 @@ public abstract class TypeEdgeIterator {
         final Seekable<TypeEdge.View.Backward, Order.Asc> edges;
         final Encoding.Edge.Type encoding;
 
-        InEdgeIteratorImpl(TypeVertex owner, Encoding.Edge.Type encoding, Seekable<TypeEdge.View.Backward, Order.Asc> edges) {
+        InEdgeIteratorImpl(Seekable<TypeEdge.View.Backward, Order.Asc> edges, TypeVertex owner, Encoding.Edge.Type encoding) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;
@@ -82,7 +82,7 @@ public abstract class TypeEdgeIterator {
         final Seekable<TypeEdge.View.Forward, Order.Asc> edges;
         final Encoding.Edge.Type encoding;
 
-        OutEdgeIteratorImpl(TypeVertex owner, Encoding.Edge.Type encoding, Seekable<TypeEdge.View.Forward, Order.Asc> edges) {
+        OutEdgeIteratorImpl(Seekable<TypeEdge.View.Forward, Order.Asc> edges, TypeVertex owner, Encoding.Edge.Type encoding) {
             this.owner = owner;
             this.edges = edges;
             this.encoding = encoding;

--- a/graph/edge/TypeEdge.java
+++ b/graph/edge/TypeEdge.java
@@ -48,4 +48,27 @@ public interface TypeEdge extends Edge<Encoding.Edge.Type, TypeVertex> {
      * @param overridden the type vertex to override by the head vertex
      */
     void overridden(TypeVertex overridden);
+
+    TypeEdge.View.Forward getForward();
+
+    TypeEdge.View.Backward getBackward();
+
+    interface View<T extends TypeEdge.View<T>> extends Comparable<T> {
+
+        EdgeViewIID.Type iid();
+
+        TypeEdge edge();
+
+        interface Forward extends TypeEdge.View<TypeEdge.View.Forward> {
+
+            @Override
+            int compareTo(Forward other);
+        }
+
+        interface Backward extends TypeEdge.View<TypeEdge.View.Backward> {
+
+            @Override
+            int compareTo(Backward other);
+        }
+    }
 }

--- a/graph/edge/impl/ThingEdgeImpl.java
+++ b/graph/edge/impl/ThingEdgeImpl.java
@@ -78,12 +78,12 @@ public abstract class ThingEdgeImpl implements ThingEdge {
 
     abstract EdgeViewIID.Thing computeBackwardIID();
 
-    public static abstract class View<T extends ThingEdge.View<T>> implements ThingEdge.View<T> {
+    private static abstract class View<T extends ThingEdge.View<T>> implements ThingEdge.View<T> {
 
         final ThingEdgeImpl edge;
         EdgeViewIID.Thing iidCache = null;
 
-        View(ThingEdgeImpl edge) {
+        private View(ThingEdgeImpl edge) {
             this.edge = edge;
         }
 
@@ -104,9 +104,9 @@ public abstract class ThingEdgeImpl implements ThingEdge {
             return edge.hashCode();
         }
 
-        public static class Forward extends ThingEdgeImpl.View<ThingEdge.View.Forward> implements ThingEdge.View.Forward {
+        private static class Forward extends ThingEdgeImpl.View<ThingEdge.View.Forward> implements ThingEdge.View.Forward {
 
-            Forward(ThingEdgeImpl edge) {
+            private Forward(ThingEdgeImpl edge) {
                 super(edge);
             }
 
@@ -122,9 +122,9 @@ public abstract class ThingEdgeImpl implements ThingEdge {
             }
         }
 
-        public static class Backward extends ThingEdgeImpl.View<ThingEdge.View.Backward> implements ThingEdge.View.Backward {
+        private static class Backward extends ThingEdgeImpl.View<ThingEdge.View.Backward> implements ThingEdge.View.Backward {
 
-            Backward(ThingEdgeImpl edge) {
+            private Backward(ThingEdgeImpl edge) {
                 super(edge);
             }
 
@@ -169,7 +169,8 @@ public abstract class ThingEdgeImpl implements ThingEdge {
          * @param to        the head vertex
          * @param optimised vertex that this optimised edge is compressing
          */
-        public Buffered(Encoding.Edge.Thing encoding, ThingVertex.Write from, ThingVertex.Write to, @Nullable ThingVertex.Write optimised, boolean isInferred) {
+        public Buffered(Encoding.Edge.Thing encoding, ThingVertex.Write from, ThingVertex.Write to,
+                        @Nullable ThingVertex.Write optimised, boolean isInferred) {
             super(from.graph(), encoding, isInferred);
             assert this.graph == to.graph();
             assert encoding.isOptimisation() || optimised == null;

--- a/graph/edge/impl/ThingEdgeImpl.java
+++ b/graph/edge/impl/ThingEdgeImpl.java
@@ -313,13 +313,15 @@ public abstract class ThingEdgeImpl implements ThingEdge {
         private final ThingVertex from;
         private final ThingVertex to;
         private final TypeVertex optimisedType;
+        private final int hash;
 
         public Target(Encoding.Edge.Thing encoding, ThingVertex from, ThingVertex to, @Nullable TypeVertex optimisedType) {
             super(from.graph(), encoding, false);
             assert !encoding.isOptimisation() || optimisedType != null;
-            this.optimisedType = optimisedType;
             this.from = from;
             this.to = to;
+            this.optimisedType = optimisedType;
+            this.hash = hash(Target.class, encoding, from, to, optimisedType);
         }
 
         @Override
@@ -387,6 +389,22 @@ public abstract class ThingEdgeImpl implements ThingEdge {
         @Override
         public void isInferred(boolean isInferred) {
             throw TypeDBException.of(ILLEGAL_OPERATION);
+        }
+
+        @Override
+        public final boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            ThingEdgeImpl.Target that = (ThingEdgeImpl.Target) object;
+            return this.encoding.equals(that.encoding) &&
+                    this.from.equals(that.from) &&
+                    this.to.equals(that.to) &&
+                    Objects.equals(this.optimisedType, that.optimisedType);
+        }
+
+        @Override
+        public final int hashCode() {
+            return hash;
         }
     }
 

--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -272,11 +272,13 @@ public abstract class TypeEdgeImpl implements TypeEdge {
 
         private final TypeVertex from;
         private final TypeVertex to;
+        private final int hash;
 
         public Target(Encoding.Edge.Type encoding, TypeVertex from, TypeVertex to) {
             super(from.graph(), encoding);
             this.from = from;
             this.to = to;
+            this.hash = hash(Target.class, from, to);
         }
 
         @Override
@@ -322,6 +324,21 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         @Override
         public void commit() {
             throw TypeDBException.of(ILLEGAL_OPERATION);
+        }
+
+        @Override
+        public final boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            TypeEdgeImpl.Target that = (TypeEdgeImpl.Target) object;
+            return this.encoding.equals(that.encoding) &&
+                    this.from.equals(that.from) &&
+                    this.to.equals(that.to);
+        }
+
+        @Override
+        public final int hashCode() {
+            return hash;
         }
     }
 
@@ -434,7 +451,7 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         @Override
         public void delete() {
             if (deleted.compareAndSet(false, true)) {
-                from().outs().remove(this); // TODO
+                from().outs().remove(this);
                 to().ins().remove(this);
                 graph.storage().deleteUntracked(getForward().iid());
                 graph.storage().deleteUntracked(getBackward().iid());

--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -37,10 +37,91 @@ public abstract class TypeEdgeImpl implements TypeEdge {
 
     final TypeGraph graph;
     final Encoding.Edge.Type encoding;
+    final View.Forward forward;
+    final View.Backward backward;
 
     TypeEdgeImpl(TypeGraph graph, Encoding.Edge.Type encoding) {
         this.graph = graph;
         this.encoding = encoding;
+        this.forward = new View.Forward(this);
+        this.backward = new View.Backward(this);
+    }
+
+    @Override
+    public View.Forward getForward() {
+        return forward;
+    }
+
+    @Override
+    public View.Backward getBackward() {
+        return backward;
+    }
+
+    abstract EdgeViewIID.Type computeForwardIID();
+
+    abstract EdgeViewIID.Type computeBackwardIID();
+
+    private static abstract class View<T extends TypeEdge.View<T>> implements TypeEdge.View<T> {
+
+        final TypeEdgeImpl edge;
+        EdgeViewIID.Type iidCache = null;
+
+        private View(TypeEdgeImpl edge) {
+            this.edge = edge;
+        }
+
+        @Override
+        public TypeEdge edge() {
+            return edge;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || this.getClass() != object.getClass()) return false;
+            return edge.equals(((TypeEdgeImpl.View<?>) object).edge);
+        }
+
+        @Override
+        public int hashCode() {
+            return edge.hashCode();
+        }
+
+        private static class Forward extends TypeEdgeImpl.View<TypeEdge.View.Forward> implements TypeEdge.View.Forward {
+
+            private Forward(TypeEdgeImpl edge) {
+                super(edge);
+            }
+
+            @Override
+            public EdgeViewIID.Type iid() {
+                if (iidCache == null) iidCache = edge.computeForwardIID();
+                return iidCache;
+            }
+
+            @Override
+            public int compareTo(TypeEdge.View.Forward other) {
+                return iid().compareTo(other.iid());
+            }
+        }
+
+        private static class Backward extends TypeEdgeImpl.View<TypeEdge.View.Backward> implements TypeEdge.View.Backward {
+
+            private Backward(TypeEdgeImpl edge) {
+                super(edge);
+            }
+
+            @Override
+            public EdgeViewIID.Type iid() {
+                if (iidCache == null) iidCache = edge.computeBackwardIID();
+                return iidCache;
+            }
+
+            @Override
+            public int compareTo(TypeEdge.View.Backward other) {
+                return iid().compareTo(other.iid());
+            }
+        }
     }
 
     /**
@@ -76,13 +157,13 @@ public abstract class TypeEdgeImpl implements TypeEdge {
             return encoding;
         }
 
-//        @Override
-        public EdgeViewIID.Type outIID() {
+        @Override
+        public EdgeViewIID.Type computeForwardIID() {
             return EdgeViewIID.Type.of(from().iid(), encoding.forward(), to().iid());
         }
 
-//        @Override
-        public EdgeViewIID.Type inIID() {
+        @Override
+        public EdgeViewIID.Type computeBackwardIID() {
             return EdgeViewIID.Type.of(to().iid(), encoding.backward(), from().iid());
         }
 
@@ -118,8 +199,8 @@ public abstract class TypeEdgeImpl implements TypeEdge {
                 from.outs().remove(this);
                 to.ins().remove(this);
                 if (from instanceof Persisted && to instanceof Persisted) {
-                    graph.storage().deleteUntracked(outIID());
-                    graph.storage().deleteUntracked(inIID());
+                    graph.storage().deleteUntracked(getForward().iid());
+                    graph.storage().deleteUntracked(getBackward().iid());
                 }
             }
         }
@@ -135,13 +216,13 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         @Override
         public void commit() {
             if (committed.compareAndSet(false, true)) {
-                if (encoding.forward() != null) {
-                    if (overridden != null) graph.storage().putUntracked(outIID(), overridden.iid().bytes());
-                    else graph.storage().putUntracked(outIID());
-                }
-                if (encoding.backward() != null) {
-                    if (overridden != null) graph.storage().putUntracked(inIID(), overridden.iid().bytes());
-                    else graph.storage().putUntracked(inIID());
+                // compute IID because vertices could have been committed
+                if (overridden != null) {
+                    graph.storage().putUntracked(computeForwardIID(), overridden.iid().bytes());
+                    graph.storage().putUntracked(computeBackwardIID(), overridden.iid().bytes());
+                } else {
+                    graph.storage().putUntracked(computeForwardIID());
+                    graph.storage().putUntracked(computeBackwardIID());
                 }
             }
         }
@@ -189,10 +270,9 @@ public abstract class TypeEdgeImpl implements TypeEdge {
      */
     public static class Persisted extends TypeEdgeImpl implements TypeEdge {
 
-        private final EdgeViewIID.Type outIID;
-        private final EdgeViewIID.Type inIID;
         private final VertexIID.Type fromIID;
         private final VertexIID.Type toIID;
+        private final Encoding.Edge.Type encoding;
         private final AtomicBoolean deleted;
         private TypeVertex from;
         private TypeVertex to;
@@ -221,17 +301,12 @@ public abstract class TypeEdgeImpl implements TypeEdge {
             if (iid.isForward()) {
                 fromIID = iid.start();
                 toIID = iid.end();
-                outIID = iid;
-                inIID = EdgeViewIID.Type.of(iid.end(), iid.encoding().backward(), iid.start());
             } else {
                 fromIID = iid.end();
                 toIID = iid.start();
-                inIID = iid;
-                outIID = EdgeViewIID.Type.of(iid.end(), iid.encoding().forward(), iid.start());
             }
-
+            encoding = iid.encoding();
             deleted = new AtomicBoolean(false);
-
             if (overriddenIID != null) this.overriddenIID = overriddenIID;
         }
 
@@ -239,14 +314,15 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         public Encoding.Edge.Type encoding() {
             return encoding;
         }
-//
-//        public EdgeViewIID.Type outIID() {
-//            return outIID;
-//        }
-//
-//        public EdgeViewIID.Type inIID() {
-//            return inIID;
-//        }
+
+        @Override
+        public EdgeViewIID.Type computeForwardIID() {
+            return EdgeViewIID.Type.of(fromIID, encoding.forward(), toIID);
+        }
+
+        public EdgeViewIID.Type computeBackwardIID() {
+            return EdgeViewIID.Type.of(toIID, encoding.backward(), fromIID);
+        }
 
         @Override
         public TypeVertex from() {
@@ -268,7 +344,6 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         public TypeVertex overridden() {
             if (overridden != null) return overridden;
             if (overriddenIID == null) return null;
-
             overridden = graph.convert(overriddenIID);
             return overridden;
         }
@@ -285,26 +360,24 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         public void overridden(TypeVertex overridden) {
             this.overridden = overridden;
             overriddenIID = overridden.iid();
-            graph.storage().putUntracked(outIID, overriddenIID.bytes());
-            graph.storage().putUntracked(inIID, overriddenIID.bytes());
+            graph.storage().putUntracked(computeForwardIID(), overriddenIID.bytes());
+            graph.storage().putUntracked(computeBackwardIID(), overriddenIID.bytes());
         }
 
         /**
          * Delete operation of a persisted edge.
          *
          * This operation can only be performed once, and thus protected by
-         * {@code isDelete} atomic boolean. The delete operation involves
-         * removing this edge from the {@code from.outs()} and {@code to.ins()}
-         * edge collections in case it is cached. Then, delete both directions
-         * of this edge from the graph storage.
+         * {@code isDelete} atomic boolean. We mark both from and to vertices
+         * as modified, and delete both directions of this edge from the graph storage.
          */
         @Override
         public void delete() {
             if (deleted.compareAndSet(false, true)) {
-                from().outs().remove(this);
+                from().outs().remove(this); // TODO
                 to().ins().remove(this);
-                graph.storage().deleteUntracked(outIID);
-                graph.storage().deleteUntracked(inIID);
+                graph.storage().deleteUntracked(getForward().iid());
+                graph.storage().deleteUntracked(getBackward().iid());
             }
         }
 

--- a/graph/vertex/TypeVertex.java
+++ b/graph/vertex/TypeVertex.java
@@ -53,9 +53,9 @@ public interface TypeVertex extends Vertex<VertexIID.Type, Encoding.Vertex.Type>
 
     void scope(String scope);
 
-    TypeAdjacency outs();
+    TypeAdjacency.Out outs();
 
-    TypeAdjacency ins();
+    TypeAdjacency.In ins();
 
     boolean isAbstract();
 

--- a/graph/vertex/impl/TypeVertexImpl.java
+++ b/graph/vertex/impl/TypeVertexImpl.java
@@ -61,8 +61,8 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
 
     final TypeGraph graph;
     final AtomicBoolean isDeleted;
-    final TypeAdjacency outs;
-    final TypeAdjacency ins;
+    final TypeAdjacency.Out outs;
+    final TypeAdjacency.In ins;
     boolean isModified;
     String label;
     String scope;
@@ -83,8 +83,8 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         this.label = label;
         this.scope = scope;
         this.isDeleted = new AtomicBoolean(false);
-        this.outs = newAdjacency(Encoding.Direction.Adjacency.OUT);
-        this.ins = newAdjacency(Encoding.Direction.Adjacency.IN);
+        this.outs = newOutAdjacency();
+        this.ins = newInAdjacency();
         outOwnsCount = UNSET_COUNT;
         outPlaysCount = UNSET_COUNT;
         outRelatesCount = UNSET_COUNT;
@@ -116,12 +116,12 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
     }
 
     @Override
-    public TypeAdjacency outs() {
+    public TypeAdjacency.Out outs() {
         return outs;
     }
 
     @Override
-    public TypeAdjacency ins() {
+    public TypeAdjacency.In ins() {
         return ins;
     }
 
@@ -160,13 +160,9 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         return Label.of(label, scope);
     }
 
-    /**
-     * Instantiates a new {@code TypeAdjacency} class
-     *
-     * @param direction the direction of the edges held in {@code TypeAdjacency}
-     * @return the new {@code TypeAdjacency} class
-     */
-    protected abstract TypeAdjacency newAdjacency(Encoding.Direction.Adjacency direction);
+    protected abstract TypeAdjacency.In newInAdjacency();
+
+    protected abstract TypeAdjacency.Out newOutAdjacency();
 
     @Override
     public boolean isEntityType() {
@@ -279,8 +275,13 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         }
 
         @Override
-        protected TypeAdjacency newAdjacency(Encoding.Direction.Adjacency direction) {
-            return new TypeAdjacencyImpl.Buffered(this, direction);
+        protected TypeAdjacency.In newInAdjacency() {
+            return new TypeAdjacencyImpl.Buffered.In(this);
+        }
+
+        @Override
+        protected TypeAdjacency.Out newOutAdjacency() {
+            return new TypeAdjacencyImpl.Buffered.Out(this);
         }
 
         @Override
@@ -415,8 +416,13 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         }
 
         @Override
-        protected TypeAdjacency newAdjacency(Encoding.Direction.Adjacency direction) {
-            return new TypeAdjacencyImpl.Persisted(this, direction);
+        protected TypeAdjacency.In newInAdjacency(){
+            return new TypeAdjacencyImpl.Persisted.In(this);
+        }
+
+        @Override
+        protected TypeAdjacency.Out newOutAdjacency(){
+            return new TypeAdjacencyImpl.Persisted.Out(this);
         }
 
         @Override

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -1235,8 +1235,7 @@ public abstract class ProcedureEdge<
                                 iter = resolveRoleTypesIter.mergeMap(ASC, rt -> rel.outs().edge(ROLEPLAYER, rt).toAndOptimised());
                             }
                         } else {
-                            throw TypeDBException.of(ILLEGAL_STATE); // TODO disallow
-//                            iter = rel.outs().edge(ROLEPLAYER).get();
+                            throw TypeDBException.of(ILLEGAL_STATE);
                         }
 
                         if (!filteredIID && to.props().hasIID()) iter = to.filterIIDOnPlayerAndRole(iter, params);
@@ -1260,9 +1259,6 @@ public abstract class ProcedureEdge<
                             ).first();
                         } else {
                             throw TypeDBException.of(ILLEGAL_STATE);
-//                            valid = rel.outs().edge(ROLEPLAYER).get().filter(
-//                                    e -> e.to().equals(player) && !scoped.contains(e.optimised().get())
-//                            ).first();
                         }
                         valid.ifPresent(kv -> scoped.push(kv.value(), order()));
                         return valid.isPresent();

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -27,7 +27,6 @@ import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.TypeGraph;
 import com.vaticle.typedb.core.graph.common.Encoding;
-import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.iid.PrefixIID;
 import com.vaticle.typedb.core.graph.iid.VertexIID;
 import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
@@ -549,9 +548,9 @@ public abstract class ProcedureEdge<
                         super(from, to, order, FORWARD, isKey);
                     }
 
-                    private FunctionalIterator<TypeEdge> ownsEdges(TypeVertex owner) {
-                        if (isKey) return owner.outs().edge(OWNS_KEY).edge();
-                        else return link(owner.outs().edge(OWNS).edge(), owner.outs().edge(OWNS_KEY).edge());
+                    private FunctionalIterator<KeyValue<TypeVertex, TypeVertex>> ownsAndOverridden(TypeVertex owner) {
+                        if (isKey) return owner.outs().edge(OWNS_KEY).toAndOverridden();
+                        else return link(owner.outs().edge(OWNS).toAndOverridden(), owner.outs().edge(OWNS_KEY).toAndOverridden());
                     }
 
                     private FunctionalIterator<TypeVertex> ownedAttributeTypes(TypeVertex owner) {
@@ -559,9 +558,9 @@ public abstract class ProcedureEdge<
                         FunctionalIterator<TypeVertex> supertypes, iterator;
 
                         supertypes = loop(owner, Objects::nonNull, o -> o.outs().edge(SUB).to().firstOrNull());
-                        iterator = supertypes.flatMap(o -> ownsEdges(o).map(e -> {
-                            if (e.overridden() != null) overriddens.add(e.overridden());
-                            if (!overriddens.contains(e.to())) return e.to();
+                        iterator = supertypes.flatMap(o -> ownsAndOverridden(o).map(e -> {
+                            if (e.value() != null) overriddens.add(e.value());
+                            if (!overriddens.contains(e.key())) return e.key();
                             else return null;
                         }).noNulls());
                         return iterator;
@@ -657,9 +656,9 @@ public abstract class ProcedureEdge<
                         FunctionalIterator<TypeVertex> supertypes, iterator;
 
                         supertypes = loop(player, Objects::nonNull, p -> p.outs().edge(SUB).to().firstOrNull());
-                        iterator = supertypes.flatMap(s -> s.outs().edge(PLAYS).edge().map(e -> {
-                            if (e.overridden() != null) overriddens.add(e.overridden());
-                            if (!overriddens.contains(e.to())) return e.to();
+                        iterator = supertypes.flatMap(s -> s.outs().edge(PLAYS).toAndOverridden().map(e -> {
+                            if (e.value() != null) overriddens.add(e.value());
+                            if (!overriddens.contains(e.key())) return e.key();
                             else return null;
                         }).noNulls());
                         return iterator;
@@ -744,9 +743,9 @@ public abstract class ProcedureEdge<
                         FunctionalIterator<TypeVertex> supertypes, iterator;
 
                         supertypes = loop(relation, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull());
-                        iterator = supertypes.flatMap(s -> s.outs().edge(RELATES).edge().map(e -> {
-                            if (e.overridden() != null) overriddens.add(e.overridden());
-                            if (!overriddens.contains(e.to())) return e.to();
+                        iterator = supertypes.flatMap(s -> s.outs().edge(RELATES).toAndOverridden().map(e -> {
+                            if (e.value() != null) overriddens.add(e.value());
+                            if (!overriddens.contains(e.key())) return e.key();
                             else return null;
                         }).noNulls());
                         return iterator;

--- a/traversal/scanner/RelationIterator.java
+++ b/traversal/scanner/RelationIterator.java
@@ -203,7 +203,7 @@ public class RelationIterator extends AbstractFunctionalIterator<VertexMap> {
     private Seekable<ThingVertex, Order.Asc> createIterator(int pos) {
         StructureEdge<?, ?> edge = edges.get(pos);
         ThingVertex player = answer.get(edge.to().id().asVariable().asRetrievable()).asThing();
-        return Iterators.Sorted.merge(ASC, iterate(edge.asNative().asRolePlayer().types()).map(roleLabel -> {
+        return Iterators.Sorted.Seekable.merge(ASC, iterate(edge.asNative().asRolePlayer().types()).map(roleLabel -> {
             TypeVertex roleVertex = graphMgr.schema().getType(roleLabel);
             return player.ins().edge(ROLEPLAYER, roleVertex)
                     .fromAndOptimised()


### PR DESCRIPTION
## What is the goal of this PR?

We propagate the pattern introduced in previous work for the `Thing` graph components to the `Type` graph: we introduce directed type vertex adjacencies (in/out), type edge views (forward/backward), and type edge iterators. By doing so we will enable using only Seekable iterators from the TypeDB thing and type graph elements.

## What are the changes implemented in this PR?

* Introduce `TypeAdjacency.In``/.Out`
  * To avoid returning edges from the 
* Introduce `TypeEdge.View.Forward``/.Backward`
* Introduce In and Out `TypeEdgeIterator`, which are used by the In and Out type adjacencies
* clean up `//common/iterators` and introduce newly required Seekable iterator: `ConsumeHandledSortedIterator`