### PR TITLE
Use seekable iterators in existing traversal engine

### DIFF
--- a/common/iterator/AbstractFunctionalIterator.java
+++ b/common/iterator/AbstractFunctionalIterator.java
@@ -28,9 +28,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -65,7 +67,7 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
     }
 
     @Override
-    public <U extends Comparable<U>, ORDER extends Order> Seekable<U, ORDER> mergeMap(
+    public <U extends Comparable<? super U>, ORDER extends Order> Seekable<U, ORDER> mergeMap(
             ORDER order, Function<T, Seekable<U, ORDER>> mappingFn
     ) {
         return new MergeMappedIterator.Seekable<>(order, this, mappingFn);
@@ -210,6 +212,13 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
         forEachRemaining(linkedSet::add);
         recycle();
         return linkedSet;
+    }
+
+    @Override
+    public NavigableSet<T> toNavigableSet() {
+        NavigableSet<T> set = new TreeSet<>();
+        this.forEachRemaining(set::add);
+        return set;
     }
 
     @Override

--- a/common/iterator/AbstractFunctionalIterator.java
+++ b/common/iterator/AbstractFunctionalIterator.java
@@ -20,19 +20,17 @@ package com.vaticle.typedb.core.common.iterator;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.sorted.MergeMappedIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -212,13 +210,6 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
         forEachRemaining(linkedSet::add);
         recycle();
         return linkedSet;
-    }
-
-    @Override
-    public NavigableSet<T> toNavigableSet() {
-        NavigableSet<T> set = new TreeSet<>();
-        this.forEachRemaining(set::add);
-        return set;
     }
 
     @Override

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -25,7 +25,6 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -85,8 +84,6 @@ public interface FunctionalIterator<T> extends Iterator<T> {
     void toSet(Set<T> set);
 
     LinkedHashSet<T> toLinkedSet();
-
-    NavigableSet<T> toNavigableSet();
 
     long count();
 

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -43,7 +43,7 @@ public interface FunctionalIterator<T> extends Iterator<T> {
 
     <U> FunctionalIterator<U> flatMap(Function<T, FunctionalIterator<U>> mappingFn);
 
-    <U extends Comparable<U>, ORDER extends Order> SortedIterator.Seekable<U, ORDER> mergeMap(
+    <U extends Comparable<? super U>, ORDER extends Order> SortedIterator.Seekable<U, ORDER> mergeMap(
             ORDER order, Function<T, SortedIterator.Seekable<U, ORDER>> mappingFn
     );
 

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -84,6 +85,8 @@ public interface FunctionalIterator<T> extends Iterator<T> {
     void toSet(Set<T> set);
 
     LinkedHashSet<T> toLinkedSet();
+
+    NavigableSet<T> toNavigableSet();
 
     long count();
 

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -61,6 +61,7 @@ public interface FunctionalIterator<T> extends Iterator<T> {
 
     boolean allMatch(Predicate<T> predicate);
 
+    // TODO: any seekable iterators using this with `equals` inside to match a  particular element should use seek()
     boolean anyMatch(Predicate<T> predicate);
 
     boolean noneMatch(Predicate<T> predicate);

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -170,8 +171,13 @@ public class Iterators {
 
         public static class Seekable {
 
-            public static <T extends Comparable<T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
+            public static <T extends Comparable<? super T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
                 return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
+            }
+
+            @SafeVarargs
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, T... elements) {
+                return new BaseSeekableIterator<>(order, new TreeSet<>(list(elements)));
             }
 
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, NavigableSet<T> set) {

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -175,6 +175,10 @@ public class Iterators {
                 return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
             }
 
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, Collection<T> elements) {
+                return new BaseSeekableIterator<>(order, new TreeSet<>(list(elements)));
+            }
+
             @SafeVarargs
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, T... elements) {
                 return new BaseSeekableIterator<>(order, new TreeSet<>(list(elements)));

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -176,7 +176,7 @@ public class Iterators {
             }
 
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, Collection<T> elements) {
-                return new BaseSeekableIterator<>(order, new TreeSet<>(list(elements)));
+                return new BaseSeekableIterator<>(order, new TreeSet<>(elements));
             }
 
             @SafeVarargs

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -172,7 +172,7 @@ public class Iterators {
         public static class Seekable {
 
             public static <T extends Comparable<? super T>> SortedIterator.Seekable<T, Order.Asc> emptySorted() {
-                return iterateSorted(SortedIterator.ASC, new ConcurrentSkipListSet<T>());
+                return iterateSorted(SortedIterator.ASC, new TreeSet<T>());
             }
 
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> iterateSorted(ORDER order, Collection<T> elements) {

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.core.common.iterator.sorted.ConsumeHandledSortedIterat
 import com.vaticle.typedb.core.common.iterator.sorted.DistinctSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FilteredSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.FinaliseSortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.LimitedSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.MappedSortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.MergeMappedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
@@ -139,6 +140,11 @@ public class Iterators {
             return new FilteredSortedIterator<>(iterator, predicate);
         }
 
+        public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator<T, ORDER> limit(SortedIterator<T, ORDER> iterator,
+                                                                                                            long limit) {
+            return new LimitedSortedIterator<>(iterator, limit);
+        }
+
         public static <T extends Comparable<? super T>, U extends Comparable<? super U>, ORDER extends Order>
         SortedIterator<U, ORDER> mapSorted(ORDER order, SortedIterator<T, ?> iterator, Function<T, U> mappingFn) {
             return new MappedSortedIterator<>(order, iterator, mappingFn);
@@ -179,6 +185,11 @@ public class Iterators {
             public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> filter(SortedIterator.Seekable<T, ORDER> iterator,
                                                                                                                           Predicate<T> predicate) {
                 return new FilteredSortedIterator.Seekable<>(iterator, predicate);
+            }
+
+            public static <T extends Comparable<? super T>, ORDER extends Order> SortedIterator.Seekable<T, ORDER> limit(SortedIterator.Seekable<T, ORDER> iterator,
+                                                                                                                         long limit) {
+                return new LimitedSortedIterator.Seekable<>(iterator, limit);
             }
 
             @SafeVarargs

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -20,7 +20,6 @@ package com.vaticle.typedb.core.common.iterator.sorted;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.AbstractFunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.ConsumeHandledIterator;
 import com.vaticle.typedb.core.common.iterator.DistinctIterator;
 import com.vaticle.typedb.core.common.iterator.ErrorHandledIterator;
 import com.vaticle.typedb.core.common.iterator.FlatMappedIterator;
@@ -112,8 +111,8 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     }
 
     @Override
-    public FunctionalIterator<T> limit(long limit) {
-        return new LimitedIterator<>(this, limit);
+    public SortedIterator<T, ORDER> limit(long limit) {
+        return new LimitedSortedIterator<>(this, limit);
     }
 
     @Override

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -35,9 +35,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -69,7 +71,7 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     }
 
     @Override
-    public <U extends Comparable<U>, ORD extends Order> Seekable<U, ORD> mergeMap(ORD order, Function<T, Seekable<U, ORD>> mappingFn) {
+    public <U extends Comparable<? super U>, ORD extends Order> Seekable<U, ORD> mergeMap(ORD order, Function<T, Seekable<U, ORD>> mappingFn) {
         return new MergeMappedIterator.Seekable<>(order, this, mappingFn);
     }
 
@@ -238,6 +240,13 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
         forEachRemaining(linkedSet::add);
         recycle();
         return linkedSet;
+    }
+
+    @Override
+    public NavigableSet<T> toNavigableSet() {
+        NavigableSet<T> set = new TreeSet<>();
+        this.forEachRemaining(set::add);
+        return set;
     }
 
     @Override

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -25,7 +25,6 @@ import com.vaticle.typedb.core.common.iterator.ErrorHandledIterator;
 import com.vaticle.typedb.core.common.iterator.FlatMappedIterator;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
-import com.vaticle.typedb.core.common.iterator.LimitedIterator;
 import com.vaticle.typedb.core.common.iterator.LinkedIterators;
 import com.vaticle.typedb.core.common.iterator.MappedIterator;
 import com.vaticle.typedb.core.common.iterator.OffsetIterator;
@@ -127,7 +126,7 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     }
 
     @Override
-    public FunctionalIterator<T> noNulls() {
+    public SortedIterator<T, ORDER> noNulls() {
         return this.filter(Objects::nonNull);
     }
 

--- a/common/iterator/sorted/BaseSeekableIterator.java
+++ b/common/iterator/sorted/BaseSeekableIterator.java
@@ -101,6 +101,11 @@ public class BaseSeekableIterator<T extends Comparable<? super T>, ORDER extends
     }
 
     @Override
+    public SortedIterator.Seekable<T, ORDER> limit(long limit) {
+        return Iterators.Sorted.Seekable.limit(this, limit);
+    }
+
+    @Override
     public Seekable<T, ORDER> onConsumed(Runnable function) {
         return Iterators.Sorted.Seekable.onConsume(this, function);
     }

--- a/common/iterator/sorted/BaseSeekableIterator.java
+++ b/common/iterator/sorted/BaseSeekableIterator.java
@@ -81,7 +81,7 @@ public class BaseSeekableIterator<T extends Comparable<? super T>, ORDER extends
 
     @Override
     public final Seekable<T, ORDER> merge(Seekable<T, ORDER> iterator) {
-        return Iterators.Sorted.Seekable.merge( this, iterator);
+        return Iterators.Sorted.Seekable.merge(this, iterator);
     }
 
     @Override

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -103,6 +103,11 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
         }
 
         @Override
+        public SortedIterator.Seekable<T, ORDER> limit(long limit) {
+            return Iterators.Sorted.Seekable.limit(this, limit);
+        }
+
+        @Override
         public SortedIterator.Seekable<T, ORDER> onConsumed(Runnable function) {
             return Iterators.Sorted.Seekable.onConsume(this, function);
         }

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -83,7 +83,7 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public final SortedIterator.Seekable<T, ORDER> merge(SortedIterator.Seekable<T, ORDER> iterator) {
-            return Iterators.Sorted.Seekable.merge( this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override

--- a/common/iterator/sorted/FilteredSortedIterator.java
+++ b/common/iterator/sorted/FilteredSortedIterator.java
@@ -94,7 +94,7 @@ public class FilteredSortedIterator<T extends Comparable<? super T>, ORDER exten
         @Override
         public <U extends Comparable<? super U>, ORD extends Order> SortedIterator.Seekable<U, ORD> mapSorted(
                 ORD order, Function<T, U> mappingFn, Function<U, T> reverseMappingFn) {
-            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn,  reverseMappingFn);
+            return Iterators.Sorted.Seekable.mapSorted(order, this, mappingFn, reverseMappingFn);
         }
 
         @Override

--- a/common/iterator/sorted/FilteredSortedIterator.java
+++ b/common/iterator/sorted/FilteredSortedIterator.java
@@ -108,6 +108,11 @@ public class FilteredSortedIterator<T extends Comparable<? super T>, ORDER exten
         }
 
         @Override
+        public SortedIterator.Seekable<T, ORDER> limit(long limit) {
+            return Iterators.Sorted.Seekable.limit(this, limit);
+        }
+
+        @Override
         public SortedIterator.Seekable<T, ORDER> onConsumed(Runnable function) {
             return Iterators.Sorted.Seekable.onConsume(this, function);
         }

--- a/common/iterator/sorted/FinaliseSortedIterator.java
+++ b/common/iterator/sorted/FinaliseSortedIterator.java
@@ -103,6 +103,11 @@ public class FinaliseSortedIterator<T extends Comparable<? super T>, ORDER exten
         }
 
         @Override
+        public SortedIterator.Seekable<T, ORDER> limit(long limit) {
+            return Iterators.Sorted.Seekable.limit(this, limit);
+        }
+
+        @Override
         public SortedIterator.Seekable<T, ORDER> onConsumed(Runnable function) {
             return Iterators.Sorted.Seekable.onConsume(this, function);
         }

--- a/common/iterator/sorted/LimitedSortedIterator.java
+++ b/common/iterator/sorted/LimitedSortedIterator.java
@@ -19,8 +19,6 @@
 package com.vaticle.typedb.core.common.iterator.sorted;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.AbstractFunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
 
 import java.util.NoSuchElementException;
@@ -91,7 +89,7 @@ public class LimitedSortedIterator<T extends Comparable<? super T>, ORDER extend
 
         @Override
         public final SortedIterator.Seekable<T, ORDER> merge(SortedIterator.Seekable<T, ORDER> iterator) {
-            return Iterators.Sorted.Seekable.merge( this, iterator);
+            return Iterators.Sorted.Seekable.merge(this, iterator);
         }
 
         @Override

--- a/common/iterator/sorted/MappedSortedIterator.java
+++ b/common/iterator/sorted/MappedSortedIterator.java
@@ -155,6 +155,11 @@ public class MappedSortedIterator<
         }
 
         @Override
+        public SortedIterator.Seekable<U, ORDER> limit(long limit) {
+            return Iterators.Sorted.Seekable.limit(this, limit);
+        }
+
+        @Override
         public SortedIterator.Seekable<U, ORDER> onConsumed(Runnable function) {
             return Iterators.Sorted.Seekable.onConsume(this, function);
         }

--- a/common/iterator/sorted/MergeMappedIterator.java
+++ b/common/iterator/sorted/MergeMappedIterator.java
@@ -180,6 +180,11 @@ public class MergeMappedIterator<T, U extends Comparable<? super U>, ORDER exten
         }
 
         @Override
+        public SortedIterator.Seekable<U, ORDER> limit(long limit) {
+            return Iterators.Sorted.Seekable.limit(this, limit);
+        }
+
+        @Override
         public SortedIterator.Seekable<U, ORDER> onConsumed(Runnable function) {
             return Iterators.Sorted.Seekable.onConsume(this, function);
         }

--- a/common/iterator/sorted/SortedIterator.java
+++ b/common/iterator/sorted/SortedIterator.java
@@ -95,9 +95,14 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends S
 
     SortedIterator<T, ORDER> merge(SortedIterator<T, ORDER> iterator);
 
+    @Override
     SortedIterator<T, ORDER> distinct();
 
+    @Override
     SortedIterator<T, ORDER> filter(Predicate<T> predicate);
+
+    @Override
+    SortedIterator<T, ORDER> limit(long limit);
 
     <U extends Comparable<? super U>, ORD extends Order> SortedIterator<U, ORD> mapSorted(ORD order, Function<T, U> mappingFn);
 
@@ -118,6 +123,8 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends S
 
         @Override
         Seekable<T, ORDER> filter(Predicate<T> predicate);
+
+        Seekable<T, ORDER> limit(long limit);
 
         <U extends Comparable<? super U>, ORD extends Order> Seekable<U, ORD> mapSorted(ORD order,
                                                                                         Function<T, U> mappingFn,

--- a/common/iterator/sorted/SortedIterator.java
+++ b/common/iterator/sorted/SortedIterator.java
@@ -106,6 +106,8 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends S
 
     <U extends Comparable<? super U>, ORD extends Order> SortedIterator<U, ORD> mapSorted(ORD order, Function<T, U> mappingFn);
 
+    NavigableSet<T> toNavigableSet();
+
     @Override
     SortedIterator<T, ORDER> onConsumed(Runnable function);
 

--- a/database/RocksIterator.java
+++ b/database/RocksIterator.java
@@ -171,6 +171,11 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
     }
 
     @Override
+    public Seekable<KeyValue<T, ByteArray>, ORDER> limit(long limit) {
+        return Iterators.Sorted.Seekable.limit(this, limit);
+    }
+
+    @Override
     public Seekable<KeyValue<T, ByteArray>, ORDER> onConsumed(Runnable function) {
         return Iterators.Sorted.Seekable.onConsume(this, function);
     }

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -122,7 +122,7 @@ public class TypeGraph {
 
         private final ConcurrentMap<TypeVertex, NavigableSet<TypeVertex>> ownedAttributeTypes;
         private final ConcurrentMap<TypeVertex, NavigableSet<TypeVertex>> ownersOfAttributeTypes;
-        private final ConcurrentMap<Label, NavigableSet<Label>> resolvedRoleTypeLabels;
+        private final ConcurrentMap<Label, Set<Label>> resolvedRoleTypeLabels;
         private final ConcurrentMap<Encoding.ValueType, NavigableSet<TypeVertex>> valueAttributeTypes;
         private NavigableSet<TypeVertex> entityTypes;
         private NavigableSet<TypeVertex> relationTypes;
@@ -303,7 +303,7 @@ public class TypeGraph {
 
     public Set<Label> resolveRoleTypeLabels(Label scopedLabel) {
         assert scopedLabel.scope().isPresent();
-        Supplier<NavigableSet<Label>> fn = () -> {
+        Supplier<Set<Label>> fn = () -> {
             TypeVertex relationType = getType(scopedLabel.scope().get());
             if (relationType == null) throw TypeDBException.of(TYPE_NOT_FOUND, scopedLabel.scope().get());
             else return link(
@@ -314,7 +314,7 @@ public class TypeGraph {
                             .flatMap(rel -> rel.outs().edge(RELATES).to())
                             .flatMap(rol -> loop(rol, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull()))
                             .filter(rol -> rol.properLabel().name().equals(scopedLabel.name()))
-            ).map(TypeVertex::properLabel).toNavigableSet();
+            ).map(TypeVertex::properLabel).toSet();
         };
         if (isReadOnly) return cache.resolvedRoleTypeLabels.computeIfAbsent(scopedLabel, l -> fn.get());
         else return fn.get();

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -43,8 +43,6 @@ import java.util.function.Predicate;
 
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
-import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 
 public abstract class TypeAdjacencyImpl<EDGE_VIEW extends TypeEdge.View<EDGE_VIEW>> implements TypeAdjacency {

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -1206,6 +1206,13 @@ public class UnifyRelationConcludableTest {
         Iterator<? extends Thing> instances = iterate(conceptMgr.getRootThingType().getInstances());
         return unifier.reverseUnifier().keySet().stream()
                 .filter(var -> !ans.contains(var.asRetrievable()))
-                .collect(Collectors.toMap(var -> var, var -> instances.next()));
+                .collect(Collectors.toMap(var -> var, var -> {
+                    if (unifier.unifiedRequirements().isaExplicit().containsKey(var.asRetrievable())) {
+                        return conceptMgr.getThingType(unifier.unifiedRequirements().isaExplicit().get(var.asRetrievable()).iterator().next().name())
+                                .getInstances().first().get();
+                    } else {
+                        return instances.next();
+                    }
+                }));
     }
 }

--- a/traversal/predicate/Predicate.java
+++ b/traversal/predicate/Predicate.java
@@ -21,6 +21,7 @@ package com.vaticle.typedb.core.traversal.predicate;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 
 import java.util.Objects;
@@ -79,7 +80,7 @@ public abstract class Predicate<PRED_OP extends PredicateOperator, PRED_ARG exte
             return argument.valueType();
         }
 
-        public boolean apply(AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+        public boolean apply(AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
             return argument.apply(operator, vertex, value);
         }
 

--- a/traversal/predicate/PredicateArgument.java
+++ b/traversal/predicate/PredicateArgument.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 
 import java.time.LocalDateTime;
 
@@ -67,13 +68,13 @@ public abstract class PredicateArgument {
             return valueType;
         }
 
-        public abstract boolean apply(ARG_VAL_OP operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value);
+        public abstract boolean apply(ARG_VAL_OP operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value);
 
         public abstract boolean apply(ARG_VAL_OP operator, AttributeVertex<?> vertex, ARG_VAL_TYPE value);
 
         public static Value<PredicateOperator.Equality, Boolean> BOOLEAN = new Value<PredicateOperator.Equality, Boolean>(Encoding.ValueType.BOOLEAN) {
             @Override
-            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
                 assert value.isBoolean();
                 return apply(operator, vertex, value.getBoolean());
             }
@@ -88,7 +89,7 @@ public abstract class PredicateArgument {
 
         public static Value<PredicateOperator.Equality, Long> LONG = new Value<PredicateOperator.Equality, Long>(Encoding.ValueType.LONG) {
             @Override
-            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
                 assert value.isLong();
                 return apply(operator, vertex, value.getLong());
             }
@@ -107,7 +108,7 @@ public abstract class PredicateArgument {
 
         public static Value<PredicateOperator.Equality, Double> DOUBLE = new Value<PredicateOperator.Equality, Double>(Encoding.ValueType.DOUBLE) {
             @Override
-            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
                 assert value.isDouble();
                 return apply(operator, vertex, value.getDouble());
             }
@@ -127,7 +128,7 @@ public abstract class PredicateArgument {
 
         public static Value<PredicateOperator.Equality, LocalDateTime> DATETIME = new Value<PredicateOperator.Equality, LocalDateTime>(Encoding.ValueType.DATETIME) {
             @Override
-            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+            public boolean apply(PredicateOperator.Equality operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
                 assert value.isDateTime();
                 return apply(operator, vertex, value.getDateTime());
             }
@@ -143,7 +144,7 @@ public abstract class PredicateArgument {
 
         public static Value<PredicateOperator, String> STRING = new Value<PredicateOperator, String>(Encoding.ValueType.STRING) {
             @Override
-            public boolean apply(PredicateOperator operator, AttributeVertex<?> vertex, GraphTraversal.Thing.Parameters.Value value) {
+            public boolean apply(PredicateOperator operator, AttributeVertex<?> vertex, Traversal.Parameters.Value value) {
                 if (!vertex.valueType().comparableTo(Encoding.ValueType.STRING)) return false;
                 assert value.isString() || value.isRegex();
                 if (operator.isSubString()) return operator.asSubString().apply(vertex.asString().value(), value);

--- a/traversal/predicate/PredicateOperator.java
+++ b/traversal/predicate/PredicateOperator.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.traversal.predicate;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 
 import java.util.Map;
@@ -191,7 +192,7 @@ public abstract class PredicateOperator {
             super(token);
         }
 
-        abstract boolean apply(String vertexValue, GraphTraversal.Thing.Parameters.Value predicateValue);
+        abstract boolean apply(String vertexValue, Traversal.Parameters.Value predicateValue);
 
         @Override
         boolean isSubString() {
@@ -205,7 +206,7 @@ public abstract class PredicateOperator {
 
         private static final SubString CONTAINS = new SubString(TypeQLToken.Predicate.SubString.CONTAINS) {
             @Override
-            boolean apply(String vertexValue, GraphTraversal.Thing.Parameters.Value predicateValue) {
+            boolean apply(String vertexValue, Traversal.Parameters.Value predicateValue) {
                 assert predicateValue.isString();
                 return containsIgnoreCase(vertexValue, predicateValue.getString());
             }
@@ -229,7 +230,7 @@ public abstract class PredicateOperator {
 
         private static final SubString LIKE = new SubString(TypeQLToken.Predicate.SubString.LIKE) {
             @Override
-            boolean apply(String vertexValue, GraphTraversal.Thing.Parameters.Value predicateValue) {
+            boolean apply(String vertexValue, Traversal.Parameters.Value predicateValue) {
                 assert predicateValue.isRegex();
                 return predicateValue.getRegex().matcher(vertexValue).matches();
             }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -24,7 +24,6 @@ import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.common.Encoding;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;
 import com.vaticle.typedb.core.traversal.planner.GraphPlanner;
@@ -169,7 +170,7 @@ public class GraphProcedure implements PermutationProcedure {
     }
 
     @Override
-    public FunctionalProducer<VertexMap> producer(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    public FunctionalProducer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
                                                   Set<Identifier.Variable.Retrievable> filter, int parallelisation) {
         if (LOG.isTraceEnabled()) {
             LOG.trace(params.toString());
@@ -190,7 +191,7 @@ public class GraphProcedure implements PermutationProcedure {
     }
 
     @Override
-    public FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    public FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
                                                   Set<Identifier.Variable.Retrievable> filter) {
         if (LOG.isTraceEnabled()) {
             LOG.trace(params.toString());

--- a/traversal/procedure/PermutationProcedure.java
+++ b/traversal/procedure/PermutationProcedure.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;
 
@@ -29,9 +30,9 @@ import java.util.Set;
 
 public interface PermutationProcedure {
 
-    FunctionalProducer<VertexMap> producer(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    FunctionalProducer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
                                            Set<Identifier.Variable.Retrievable> filter, int parallelisation);
 
-    FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
                                            Set<Identifier.Variable.Retrievable> filter);
 }

--- a/traversal/procedure/PermutationProcedure.java
+++ b/traversal/procedure/PermutationProcedure.java
@@ -21,7 +21,6 @@ package com.vaticle.typedb.core.traversal.procedure;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -244,17 +244,13 @@ public abstract class ProcedureEdge<
                 GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
             assert fromVertex.isThing() && fromVertex.asThing().isAttribute();
 
-            // TODO: can we get rid of the ? extends and then make use of mapSorted to bring back AttributeVertex<?>
-
             Seekable<? extends ThingVertex, Order.Asc> toIter;
-
             if (to.props().hasIID()) {
-                toIter = to.iterateAndFilterFromIID(graphMgr, params)
-                        .filter(ThingVertex::isAttribute);
+                toIter = to.iterateAndFilterFromIID(graphMgr, params);
             } else if (!to.props().types().isEmpty()) {
-                toIter = to.iterateAndFilterFromTypes(graphMgr, params)
-                        .filter(ThingVertex::isAttribute);
+                toIter = to.iterateAndFilterFromTypes(graphMgr, params);
             } else {
+                // TODO this branch shouldn't exist anymore
                 assert !to.isStartingVertex();
                 toIter = iterate(fromVertex.asThing().asAttribute().valueType().comparables())
                         .flatMap(vt -> graphMgr.schema().attributeTypes(vt))

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -33,8 +33,6 @@ import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
-import com.vaticle.typedb.core.traversal.GraphTraversal.Thing;
 import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.graph.TraversalEdge;
@@ -56,7 +54,6 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNR
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNSUPPORTED_OPERATION;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
-import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.loop;

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -261,7 +261,7 @@ public abstract class ProcedureEdge<
                 }
             }
 
-            return toIter.filter(toVertex -> predicate.apply(fromVertex.asThing().asAttribute(), toVertex));
+            return toIter.filter(toVertex -> predicate.apply(fromVertex.asThing().asAttribute(), toVertex.asAttribute()));
         }
 
         @Override
@@ -354,7 +354,8 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public Seekable<? extends Vertex<?, ?>, Order.Asc> branch(
-                        GraphManager graphMgr, Vertex<?, ?> fromVertex, Thing.Parameters params) {
+                        GraphManager graphMgr, Vertex<?, ?> fromVertex, GraphTraversal.Thing.Parameters params
+                ) {
                     assert fromVertex.isThing();
                     FunctionalIterator<TypeVertex> iter = isaTypes(fromVertex.asThing());
                     return to.filter(iter);

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
@@ -330,9 +331,9 @@ public abstract class ProcedureEdge<
             Seekable<TypeVertex, Order.Asc> isaTypes(ThingVertex thing) {
                 if (!isTransitive) return iterateSorted(ASC, thing.type());
                 else {
-                    return iterateSorted(
-                            ASC, loop(thing.type(), Objects::nonNull, v -> v.outs().edge(SUB).to().firstOrNull()).toNavigableSet()
-                    );
+                    TreeSet<TypeVertex> superTypes = new TreeSet<>();
+                    loop(thing.type(), Objects::nonNull, v -> v.outs().edge(SUB).to().firstOrNull()).forEachRemaining(superTypes::add);
+                    return iterateSorted(ASC, superTypes);
                 }
             }
 
@@ -472,9 +473,9 @@ public abstract class ProcedureEdge<
                 Seekable<TypeVertex, Order.Asc> superTypes(TypeVertex type) {
                     if (!isTransitive) return type.outs().edge(SUB).to();
                     else {
-                        return iterateSorted(
-                                ASC, loop(type, Objects::nonNull, v -> v.outs().edge(SUB).to().firstOrNull()).toNavigableSet()
-                        );
+                        TreeSet<TypeVertex> superTypes = new TreeSet<>();
+                        loop(type, Objects::nonNull, v -> v.outs().edge(SUB).to().firstOrNull()).forEachRemaining(superTypes::add);
+                        return iterateSorted(ASC, superTypes);
                     }
                 }
 
@@ -521,7 +522,11 @@ public abstract class ProcedureEdge<
                         Seekable<TypeVertex, Order.Asc> iter;
                         TypeVertex type = fromVertex.asType();
                         if (!isTransitive) iter = type.ins().edge(SUB).from();
-                        else iter = iterateSorted(ASC, tree(type, t -> t.ins().edge(SUB).from()).toNavigableSet());
+                        else {
+                            TreeSet<TypeVertex> subtypes = new TreeSet<>();
+                            tree(type, t -> t.ins().edge(SUB).from()).forEachRemaining(subtypes::add);
+                            iter = iterateSorted(ASC, subtypes);
+                        }
                         return to.filter(iter);
                     }
 
@@ -641,7 +646,9 @@ public abstract class ProcedureEdge<
                             GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
                         assert fromVertex.isType();
                         // TODO: this should read from type graph cache
-                        return to.filter(iterateSorted(ASC, ownersOfAttType(fromVertex.asType()).toNavigableSet()));
+                        TreeSet<TypeVertex> ownerTypes = new TreeSet<>();
+                        ownersOfAttType(fromVertex.asType()).forEachRemaining(ownerTypes::add);
+                        return to.filter(iterateSorted(ASC, ownerTypes));
                     }
 
                     @Override
@@ -693,7 +700,9 @@ public abstract class ProcedureEdge<
                             GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
                         assert fromVertex.isType();
                         // TODO: this should read from type graph cache
-                        return to.filter(iterateSorted(ASC, playedRoleTypes(fromVertex.asType()).toNavigableSet()));
+                        TreeSet<TypeVertex> roleTypes = new TreeSet<>();
+                        playedRoleTypes(fromVertex.asType()).forEachRemaining(roleTypes::add);
+                        return to.filter(iterateSorted(ASC, roleTypes));
                     }
 
                     @Override
@@ -730,7 +739,9 @@ public abstract class ProcedureEdge<
                             GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
                         assert fromVertex.isType();
                         // TODO: this should read from type graph cache
-                        return to.filter(iterateSorted(ASC, playersOfRoleType(fromVertex.asType()).toNavigableSet()));
+                        TreeSet<TypeVertex> playerTypes = new TreeSet<>();
+                        playersOfRoleType(fromVertex.asType()).forEachRemaining(playerTypes::add);
+                        return to.filter(iterateSorted(ASC, playerTypes));
                     }
 
                     @Override
@@ -782,7 +793,9 @@ public abstract class ProcedureEdge<
                             GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
                         assert fromVertex.isType();
                         // TODO: this should read from type graph cache
-                        return to.filter(iterateSorted(ASC, relatedRoleTypes(fromVertex.asType()).toNavigableSet()));
+                        TreeSet<TypeVertex> roleTypes = new TreeSet<>();
+                        relatedRoleTypes(fromVertex.asType()).forEachRemaining(roleTypes::add);
+                        return to.filter(iterateSorted(ASC, roleTypes));
                     }
 
                     @Override
@@ -819,7 +832,9 @@ public abstract class ProcedureEdge<
                             GraphManager graphMgr, Vertex<?, ?> fromVertex, Traversal.Parameters params) {
                         assert fromVertex.isType();
                         // TODO: this should read from type graph cache
-                        return to.filter(iterateSorted(ASC, relationsOfRoleType(fromVertex.asType()).toNavigableSet()));
+                        TreeSet<TypeVertex> relations = new TreeSet<>();
+                        relationsOfRoleType(fromVertex.asType()).forEachRemaining(relations::add);
+                        return to.filter(iterateSorted(ASC, relations));
                     }
 
                     @Override

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -224,8 +224,7 @@ public abstract class ProcedureVertex<
             if (vertex == null) return emptySorted();
             Seekable<? extends ThingVertex, Order.Asc> iter = iterateSorted(ASC, vertex);
             if (!props().types().isEmpty()) iter = filterTypes(iter);
-            if (!props().predicates().isEmpty())
-                iter = filterPredicates(filterAttributes(iter), parameters);
+            if (!props().predicates().isEmpty()) iter = filterPredicates(filterAttributes(iter), parameters);
             return iter;
         }
 
@@ -243,8 +242,7 @@ public abstract class ProcedureVertex<
             }
 
             if (props().predicates().isEmpty()) return iter;
-            else
-                return filterPredicates(filterAttributes(iter), parameters, eq.orElse(null));
+            else return filterPredicates(filterAttributes(iter), parameters, eq.orElse(null));
         }
 
         Seekable<? extends ThingVertex, Order.Asc> filterIID(Seekable<? extends ThingVertex, Order.Asc> iterator,
@@ -300,8 +298,8 @@ public abstract class ProcedureVertex<
         }
 
         Seekable<? extends AttributeVertex<?>, Order.Asc> iteratorOfAttributesWithTypes(GraphManager graphMgr,
-                                                                              Traversal.Parameters params,
-                                                                              Predicate.Value<?> eq) {
+                                                                                        Traversal.Parameters params,
+                                                                                        Predicate.Value<?> eq) {
             FunctionalIterator<TypeVertex> attributeTypes = iterate(props().types().iterator())
                     .map(l -> graphMgr.schema().getType(l)).noNulls()
                     .map(t -> {

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -31,7 +31,6 @@ import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.graph.TraversalVertex;

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -163,9 +163,7 @@ public abstract class ProcedureVertex<
                                                           Traversal.Parameters params) {
             if (props().hasIID()) iterator = filterIID(iterator, params);
             if (!props().types().isEmpty()) iterator = filterTypes(iterator);
-            if (!props().predicates().isEmpty()) {
-                iterator = filterPredicates(filterAttributes(iterator), params);
-            }
+            if (!props().predicates().isEmpty()) iterator = filterPredicates(filterAttributes(iterator), params);
             return iterator;
         }
 

--- a/traversal/procedure/VertexProcedure.java
+++ b/traversal/procedure/VertexProcedure.java
@@ -22,7 +22,6 @@ import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;

--- a/traversal/procedure/VertexProcedure.java
+++ b/traversal/procedure/VertexProcedure.java
@@ -23,6 +23,7 @@ import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;
 import com.vaticle.typedb.core.traversal.structure.StructureEdge;
@@ -80,7 +81,7 @@ public class VertexProcedure implements PermutationProcedure {
     }
 
     @Override
-    public FunctionalProducer<VertexMap> producer(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    public FunctionalProducer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
                                                   Set<Identifier.Variable.Retrievable> filter, int parallelisation) {
         LOG.trace(params.toString());
         LOG.trace(this.toString());
@@ -88,7 +89,7 @@ public class VertexProcedure implements PermutationProcedure {
     }
 
     @Override
-    public FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, GraphTraversal.Thing.Parameters params,
+    public FunctionalIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
                                                   Set<Identifier.Variable.Retrievable> filter) {
         LOG.trace(params.toString());
         LOG.trace(this.toString());

--- a/traversal/scanner/CombinationFinder.java
+++ b/traversal/scanner/CombinationFinder.java
@@ -134,7 +134,7 @@ public class CombinationFinder {
         }
     }
 
-    private boolean addOrIntersect(Identifier identifier, Set<TypeVertex> types) {
+    private boolean addOrIntersect(Identifier identifier, Set<? extends TypeVertex> types) {
         Set<TypeVertex> vertices = combination.computeIfAbsent(identifier, (id) -> new HashSet<>());
         int sizeBefore = vertices.size();
         if (vertices.isEmpty()) vertices.addAll(types);
@@ -142,8 +142,8 @@ public class CombinationFinder {
         return vertices.size() != sizeBefore;
     }
 
-    private FunctionalIterator<TypeVertex> vertexIter(ProcedureVertex.Type vertex) {
-        FunctionalIterator<TypeVertex> iterator = vertex.iterator(graphMgr, params);
+    private FunctionalIterator<? extends TypeVertex> vertexIter(ProcedureVertex.Type vertex) {
+        FunctionalIterator<? extends TypeVertex> iterator = vertex.iterator(graphMgr, params);
         if (vertex.id().isRetrievable() && concreteVarIds.contains(vertex.id().asVariable().asRetrievable())) {
             iterator = iterator.filter(type -> !type.isAbstract());
         }

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -27,6 +27,7 @@ import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable;
 import com.vaticle.typedb.core.traversal.common.VertexMap;
@@ -45,6 +46,7 @@ import java.util.TreeMap;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static java.util.stream.Collectors.toMap;
 
 public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
@@ -53,7 +55,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private final GraphManager graphMgr;
     private final GraphProcedure procedure;
-    private final GraphTraversal.Thing.Parameters params;
+    private final Traversal.Parameters params;
     private final Set<Retrievable> filter;
     private final Map<Identifier, Seekable<? extends Vertex<?, ?>, Order.Asc>> iterators;
     private final Map<Identifier, Vertex<?, ?>> answer;
@@ -66,7 +68,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     enum State {INIT, EMPTY, FETCHED, COMPLETED}
 
     public GraphIterator(GraphManager graphMgr, Vertex<?, ?> start, GraphProcedure procedure,
-                         GraphTraversal.Thing.Parameters params, Set<Retrievable> filter) {
+                         Traversal.Parameters params, Set<Retrievable> filter) {
         assert procedure.edgesCount() > 0;
         this.graphMgr = graphMgr;
         this.procedure = procedure;
@@ -301,7 +303,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
                     else scoped.push(thingAndRole.value(), edge.order());
                     return true;
                 }
-            }).map(KeyValue::key);
+            }).mapSorted(ASC, KeyValue::key, key -> KeyValue.of(key, null));
         } else {
             toIter = edge.branch(graphMgr, fromVertex, params);
         }

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -21,7 +21,8 @@ package com.vaticle.typedb.core.traversal.scanner;
 import com.vaticle.typedb.core.common.collection.KeyValue;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.AbstractFunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.Vertex;
@@ -54,7 +55,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     private final GraphProcedure procedure;
     private final GraphTraversal.Thing.Parameters params;
     private final Set<Retrievable> filter;
-    private final Map<Identifier, FunctionalIterator<? extends Vertex<?, ?>>> iterators;
+    private final Map<Identifier, Seekable<? extends Vertex<?, ?>, Order.Asc>> iterators;
     private final Map<Identifier, Vertex<?, ?>> answer;
     private final Scopes scopes;
     private final BranchSeekStack branchSeekStack;
@@ -125,7 +126,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         ProcedureEdge<?, ?> edge = procedure.edge(pos);
         Identifier toID = edge.to().id();
         Identifier fromId = edge.from().id();
-        FunctionalIterator<? extends Vertex<?, ?>> toIter = branch(answer.get(fromId), edge);
+        Seekable<? extends Vertex<?, ?>, Order.Asc> toIter = branch(answer.get(fromId), edge);
 
         if (toIter.hasNext()) {
             iterators.put(toID, toIter);
@@ -212,7 +213,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
                 if (isClosure(edge, fromVertex, toVertex)) return true;
                 else return computeNextClosure(pos);
             } else {
-                FunctionalIterator<? extends Vertex<?, ?>> toIter = branch(answer.get(edge.from().id()), edge);
+                Seekable<? extends Vertex<?, ?>, Order.Asc> toIter = branch(answer.get(edge.from().id()), edge);
                 iterators.put(toID, toIter);
             }
         }
@@ -243,7 +244,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private boolean computeNextBranch(int pos) {
         ProcedureEdge<?, ?> edge = procedure.edge(pos);
-        FunctionalIterator<? extends Vertex<?, ?>> newIter;
+        Seekable<? extends Vertex<?, ?>, Order.Asc> newIter;
 
         do {
             if (backTrack(pos)) {
@@ -277,8 +278,8 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         }
     }
 
-    private FunctionalIterator<? extends Vertex<?, ?>> branch(Vertex<?, ?> fromVertex, ProcedureEdge<?, ?> edge) {
-        FunctionalIterator<? extends Vertex<?, ?>> toIter;
+    private Seekable<? extends Vertex<?, ?>, Order.Asc> branch(Vertex<?, ?> fromVertex, ProcedureEdge<?, ?> edge) {
+        Seekable<? extends Vertex<?, ?>, Order.Asc> toIter;
         if (edge.to().id().isScoped()) {
             Identifier.Variable scope = edge.to().id().asScoped().scope();
             Scopes.Scoped scoped = scopes.getOrInitialise(scope);


### PR DESCRIPTION
## What is the goal of this PR?

We utilise Seekable iterators throughout the the existing traversal engine, updating existing traversal and procedure APIs to also utilise Seekable iterators. 

## What are the changes implemented in this PR?

* Update `ProcedureEdge.branch()` to use `Seekable` iterators instead of just `FunctionalIterator`
* Update `ProcedureVertex.iterate()` to use `Seekable` iterators instead of just `FunctionalIterator`
* Propagate seekable iterators throughout the various procedures and the Graph iterator