### PR TITLE
Simplify query engine under assumption of type inference

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -565,8 +565,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
         public static final RuleWrite RULE_CONCLUSION_ILLEGAL_INSERT =
                 new RuleWrite(4, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
-        public static final RuleWrite RULE_CONCLUSION_AMBIGUOUS_TYPES =
-                new RuleWrite(5, "The conclusion of rule '%s' contains '%s', which could represent types '%s' but may must represent only one.");
+        public static final RuleWrite RULE_CONCLUSION_AMBIGUOUS_LABELLED_TYPE =
+                new RuleWrite(5, "The conclusion of rule '%s' contains ambiguous label '%s' (could represent: '%s'). ");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -563,16 +563,18 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
         public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
                 new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
-        public static final RuleWrite RULE_CAN_HAVE_INVALID_CONCLUSION =
-                new RuleWrite(4, "The rule '%s''s conclusion may insert types '%s', which is not allowed in the current schema.");
+        public static final RuleWrite RULE_CONCLUSION_ILLEGAL_INSERT =
+                new RuleWrite(4, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
+        public static final RuleWrite RULE_CONCLUSION_AMBIGUOUS_TYPES =
+                new RuleWrite(5, "The conclusion of rule '%s' contains '%s', which could represent types '%s' but may must represent only one.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(6, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_INVALID_VALUE_ASSIGNMENT =
-                new RuleWrite(7, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
+                new RuleWrite(8, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
         public static final RuleWrite MAX_RULE_REACHED =
-                new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
+                new RuleWrite(9, "The maximum number of rules has been reached: '%s'");
 
         private static final String codePrefix = "RUW";
         private static final String messagePrefix = "Invalid Rule Write";

--- a/graph/ThingGraph.java
+++ b/graph/ThingGraph.java
@@ -43,6 +43,7 @@ import com.vaticle.typedb.core.graph.vertex.impl.AttributeVertexImpl;
 import com.vaticle.typedb.core.graph.vertex.impl.ThingVertexImpl;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -621,15 +622,14 @@ public class ThingGraph {
             return vertexCount(type.iid(), true);
         }
 
-        public long thingVertexTransitiveMax(Set<Label> labels, Set<Label> filter) {
-            return thingVertexTransitiveMax(labels.stream().map(typeGraph::getType), filter);
+        public long thingVertexTransitiveMax(Set<Label> labels) {
+            return thingVertexTransitiveMax(iterate(labels).map(typeGraph::getType));
         }
 
-        public long thingVertexTransitiveMax(Stream<TypeVertex> types, Set<Label> filter) {
-            return types.mapToLong(t -> tree(t, v -> v.ins().edge(SUB).from()
-                    .filter(tf -> !filter.contains(tf.properLabel())))
+        public long thingVertexTransitiveMax(FunctionalIterator<TypeVertex> types) {
+            return types.map(t -> tree(t, v -> v.ins().edge(SUB).from())
                     .stream().mapToLong(this::thingVertexCount).sum()
-            ).max().orElse(0);
+            ).stream().max(Comparator.naturalOrder()).orElse(0L);
         }
 
         public boolean needsBackgroundCounting() {

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -315,7 +315,7 @@ public class TypeGraph {
             TypeVertex relationType = getType(scopedLabel.scope().get());
             if (relationType == null) throw TypeDBException.of(TYPE_NOT_FOUND, scopedLabel.scope().get());
             else {
-                FunctionalIterator<TypeVertex> roleTypes = link(
+                return link(
                         loop(relationType, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull())
                                 .flatMap(rel -> rel.outs().edge(RELATES).to())
                                 .filter(rol -> rol.properLabel().name().equals(scopedLabel.name())),
@@ -323,9 +323,7 @@ public class TypeGraph {
                                 .flatMap(rel -> rel.outs().edge(RELATES).to())
                                 .flatMap(rol -> loop(rol, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull()))
                                 .filter(rol -> rol.properLabel().name().equals(scopedLabel.name()))
-                );
-                return roleTypes.flatMap(rt -> tree(rt, r -> r.ins().edge(SUB).from()))
-                        .map(TypeVertex::properLabel).toSet();
+                ).map(TypeVertex::properLabel).toSet();
             }
         };
         if (isReadOnly) return cache.resolvedRoleTypeLabels.computeIfAbsent(scopedLabel, l -> fn.get());

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -314,15 +314,19 @@ public class TypeGraph {
         Supplier<Set<Label>> fn = () -> {
             TypeVertex relationType = getType(scopedLabel.scope().get());
             if (relationType == null) throw TypeDBException.of(TYPE_NOT_FOUND, scopedLabel.scope().get());
-            else return link(
-                    loop(relationType, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull())
-                            .flatMap(rel -> rel.outs().edge(RELATES).to())
-                            .filter(rol -> rol.properLabel().name().equals(scopedLabel.name())),
-                    tree(relationType, rel -> rel.ins().edge(SUB).from())
-                            .flatMap(rel -> rel.outs().edge(RELATES).to())
-                            .flatMap(rol -> loop(rol, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull()))
-                            .filter(rol -> rol.properLabel().name().equals(scopedLabel.name()))
-            ).map(TypeVertex::properLabel).toSet();
+            else {
+                FunctionalIterator<TypeVertex> roleTypes = link(
+                        loop(relationType, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull())
+                                .flatMap(rel -> rel.outs().edge(RELATES).to())
+                                .filter(rol -> rol.properLabel().name().equals(scopedLabel.name())),
+                        tree(relationType, rel -> rel.ins().edge(SUB).from())
+                                .flatMap(rel -> rel.outs().edge(RELATES).to())
+                                .flatMap(rol -> loop(rol, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull()))
+                                .filter(rol -> rol.properLabel().name().equals(scopedLabel.name()))
+                );
+                return roleTypes.flatMap(rt -> tree(rt, r -> r.ins().edge(SUB).from()))
+                        .map(TypeVertex::properLabel).toSet();
+            }
         };
         if (isReadOnly) return cache.resolvedRoleTypeLabels.computeIfAbsent(scopedLabel, l -> fn.get());
         else return fn.get();

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -66,7 +66,7 @@ import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_AMBIGUOUS_TYPES;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_AMBIGUOUS_LABELLED_TYPE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_ILLEGAL_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_ASSIGNMENT;
@@ -407,8 +407,8 @@ public class Rule {
             Optional<Variable> ambiguousVar = iterate(clonedThen.variables())
                     .filter(var -> var.isType() && var.id().isLabel() && var.inferredTypes().size() != 1).first();
             if (ambiguousVar.isPresent()) {
-                throw TypeDBException.of(RULE_CONCLUSION_AMBIGUOUS_TYPES,
-                        rule.structure.label(), ambiguousVar.get(), ambiguousVar.get().inferredTypes());
+                throw TypeDBException.of(RULE_CONCLUSION_AMBIGUOUS_LABELLED_TYPE,
+                        rule.structure.label(), ambiguousVar.get().id(), ambiguousVar.get().inferredTypes());
             }
 
             FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenTypes = logicMgr.typeInference().typePermutations(rule.when, false);

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -66,7 +66,8 @@ import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CAN_HAVE_INVALID_CONCLUSION;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_AMBIGUOUS_TYPES;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_ILLEGAL_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_ASSIGNMENT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
@@ -179,7 +180,6 @@ public class Rule {
         if (!when.isCoherent()) throw TypeDBException.of(RULE_WHEN_CANNOT_BE_SATISFIED, structure.label(), when);
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_CANNOT_BE_SATISFIED, structure.label(), then);
     }
-
 
     /**
      * Remove type hints in the `then` pattern that are not valid in the `when` pattern
@@ -402,12 +402,21 @@ public class Rule {
         }
 
         private void validateInsertable(LogicManager logicMgr) {
+            Conjunction clonedThen = rule.then.clone();
+            logicMgr.typeInference().infer(clonedThen, true);
+            Optional<Variable> ambiguousVar = iterate(clonedThen.variables())
+                    .filter(var -> var.isType() && var.id().isLabel() && var.inferredTypes().size() != 1).first();
+            if (ambiguousVar.isPresent()) {
+                throw TypeDBException.of(RULE_CONCLUSION_AMBIGUOUS_TYPES,
+                        rule.structure.label(), ambiguousVar.get(), ambiguousVar.get().inferredTypes());
+            }
+
             FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenTypes = logicMgr.typeInference().typePermutations(rule.when, false);
             Set<Map<Identifier.Variable.Name, Label>> allowedThenTypes = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
 
             whenTypes.forEachRemaining(nameLabelMap -> {
                 if (allowedThenTypes.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
-                    throw TypeDBException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
+                    throw TypeDBException.of(RULE_CONCLUSION_ILLEGAL_INSERT, rule.structure.label(), nameLabelMap.toString());
             });
         }
 

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -298,13 +298,13 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
 
         public static Relation of(RelationConstraint relation, @Nullable IsaConstraint isa, Set<LabelConstraint> labels) {
-            Conjunction.Cloner cloner;
+            Conjunction.ConstraintCloner cloner;
             IsaConstraint clonedIsa;
             if (isa == null) {
-                cloner = Conjunction.Cloner.cloneExactly(labels, relation);
+                cloner = Conjunction.ConstraintCloner.cloneExactly(labels, relation);
                 clonedIsa = null;
             } else {
-                cloner = Conjunction.Cloner.cloneExactly(labels, isa, relation);
+                cloner = Conjunction.ConstraintCloner.cloneExactly(labels, isa, relation);
                 clonedIsa = cloner.getClone(isa).asThing().asIsa();
             }
             return new Relation(cloner.conjunction(), cloner.getClone(relation).asThing().asRelation(), clonedIsa,
@@ -479,13 +479,13 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
 
         public static Has of(HasConstraint has, @Nullable IsaConstraint isa, Set<ValueConstraint<?>> values, Set<LabelConstraint> labels) {
-            Conjunction.Cloner cloner;
+            Conjunction.ConstraintCloner cloner;
             IsaConstraint clonedIsa;
             if (isa == null) {
-                cloner = Conjunction.Cloner.cloneExactly(values, has);
+                cloner = Conjunction.ConstraintCloner.cloneExactly(values, has);
                 clonedIsa = null;
             } else {
-                cloner = Conjunction.Cloner.cloneExactly(labels, values, isa, has);
+                cloner = Conjunction.ConstraintCloner.cloneExactly(labels, values, isa, has);
                 clonedIsa = cloner.getClone(isa).asThing().asIsa();
             }
             FunctionalIterator<ValueConstraint<?>> valueIt = iterate(values).map(cloner::getClone).map(c -> c.asThing().asValue());
@@ -610,7 +610,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
 
         public static Isa of(IsaConstraint isa, Set<ValueConstraint<?>> values, Set<LabelConstraint> labelConstraints) {
-            Conjunction.Cloner cloner = Conjunction.Cloner.cloneExactly(labelConstraints, values, isa);
+            Conjunction.ConstraintCloner cloner = Conjunction.ConstraintCloner.cloneExactly(labelConstraints, values, isa);
             FunctionalIterator<ValueConstraint<?>> valueIt = iterate(values).map(cloner::getClone).map(c -> c.asThing().asValue());
             return new Isa(cloner.conjunction(), cloner.getClone(isa).asThing().asIsa(), valueIt.toSet());
         }
@@ -737,7 +737,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
 
         public static Attribute of(ThingVariable attribute, Set<ValueConstraint<?>> values) {
             assert iterate(values).map(ThingConstraint::owner).toSet().equals(set(attribute));
-            Conjunction.Cloner cloner = Conjunction.Cloner.cloneExactly(values);
+            Conjunction.ConstraintCloner cloner = Conjunction.ConstraintCloner.cloneExactly(values);
             assert cloner.conjunction().variables().size() == 1;
             FunctionalIterator<ValueConstraint<?>> valueIt = iterate(values).map(v -> cloner.getClone(v).asThing().asValue());
             return new Attribute(cloner.conjunction().variables().iterator().next().asThing(), valueIt.toSet());

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -107,7 +107,7 @@ public class Retrievable extends Resolvable<Conjunction> {
                         .filter(Constraint::isType).map(Constraint::asType).filter(TypeConstraint::isLabel).toSet();
                 Set<? extends Constraint> otherConstraints = new HashSet<>(subgraph.registeredConstraints);
                 otherConstraints.removeAll(labelConstraints);
-                Conjunction.Cloner cloner = Conjunction.Cloner.cloneExactly(labelConstraints, otherConstraints);
+                Conjunction.ConstraintCloner cloner = Conjunction.ConstraintCloner.cloneExactly(labelConstraints, otherConstraints);
                 return new Retrievable(cloner.conjunction());
             }).toSet();
         }

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -384,14 +384,6 @@ public class TypeInference {
             }
         }
 
-        private TypeVariable registerRolePlayer(Retrievable ownerID, RelationConstraint.RolePlayer rolePlayer) {
-            Pair<Identifier.Variable, RelationConstraint.RolePlayer> ownerAndPlayer = new Pair<>(ownerID, rolePlayer);
-            if (rolePlayerToInference.containsKey(ownerAndPlayer)) return rolePlayerToInference.get(ownerAndPlayer);
-            TypeVariable inferenceVar = new TypeVariable(newID());
-            rolePlayerToInference.put(ownerAndPlayer, inferenceVar);
-            return inferenceVar;
-        }
-
         private void registerInsertableRelation(TypeVariable inferenceVar, RelationConstraint constraint) {
             for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
                 TypeVariable playerVar = register(rolePlayer.player());
@@ -406,6 +398,14 @@ public class TypeInference {
                 traversal.relates(inferenceVar.id(), roleTypeVar.id());
                 traversal.plays(playerVar.id(), roleTypeVar.id());
             }
+        }
+
+        private TypeVariable registerRolePlayer(Retrievable ownerID, RelationConstraint.RolePlayer rolePlayer) {
+            Pair<Identifier.Variable, RelationConstraint.RolePlayer> ownerAndPlayer = new Pair<>(ownerID, rolePlayer);
+            if (rolePlayerToInference.containsKey(ownerAndPlayer)) return rolePlayerToInference.get(ownerAndPlayer);
+            TypeVariable inferenceVar = new TypeVariable(newID());
+            rolePlayerToInference.put(ownerAndPlayer, inferenceVar);
+            return inferenceVar;
         }
 
         private void registerSubAttribute(Variable inferenceVar) {

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -231,37 +231,37 @@ public class Conjunction implements Pattern, Cloneable {
         return hash;
     }
 
-    public static class Cloner {
+    public static class ConstraintCloner {
 
         private final Map<Identifier.Variable, Variable> variables;
         private final Map<Constraint, Constraint> constraints;
 
-        public Cloner() {
+        public ConstraintCloner() {
             variables = new HashMap<>();
             constraints = new HashMap<>();
         }
 
-        public static Cloner cloneExactly(Set<? extends Constraint> s1, Constraint... s2) {
+        public static ConstraintCloner cloneExactly(Set<? extends Constraint> s1, Constraint... s2) {
             LinkedHashSet<Constraint> ordered = new LinkedHashSet<>(s1);
             Collections.addAll(ordered, s2);
             return cloneExactly(ordered);
         }
 
-        public static Cloner cloneExactly(Set<? extends Constraint> s1, Set<? extends Constraint> s2, Constraint... s3) {
+        public static ConstraintCloner cloneExactly(Set<? extends Constraint> s1, Set<? extends Constraint> s2, Constraint... s3) {
             LinkedHashSet<Constraint> ordered = new LinkedHashSet<>(s1);
             ordered.addAll(s2);
             Collections.addAll(ordered, s3);
             return cloneExactly(ordered);
         }
 
-        public static Cloner cloneExactly(Constraint constraint) {
+        public static ConstraintCloner cloneExactly(Constraint constraint) {
             LinkedHashSet<Constraint> orderedSet = new LinkedHashSet<>();
             orderedSet.add(constraint);
             return cloneExactly(orderedSet);
         }
 
-        private static Cloner cloneExactly(LinkedHashSet<? extends Constraint> constraints) {
-            Cloner cloner = new Cloner();
+        private static ConstraintCloner cloneExactly(LinkedHashSet<? extends Constraint> constraints) {
+            ConstraintCloner cloner = new ConstraintCloner();
             constraints.forEach(cloner::clone);
             return cloner;
         }

--- a/pattern/constraint/Constraint.java
+++ b/pattern/constraint/Constraint.java
@@ -60,5 +60,5 @@ public abstract class Constraint {
     @Override
     public abstract int hashCode();
 
-    public abstract Constraint clone(Conjunction.Cloner constraintCloner);
+    public abstract Constraint clone(Conjunction.ConstraintCloner constraintCloner);
 }

--- a/pattern/constraint/thing/HasConstraint.java
+++ b/pattern/constraint/thing/HasConstraint.java
@@ -97,7 +97,7 @@ public class HasConstraint extends ThingConstraint implements AlphaEquivalent<Ha
     }
 
     @Override
-    public HasConstraint clone(Conjunction.Cloner cloner) {
+    public HasConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).has(cloner.cloneVariable(attribute));
     }
 }

--- a/pattern/constraint/thing/IIDConstraint.java
+++ b/pattern/constraint/thing/IIDConstraint.java
@@ -87,7 +87,7 @@ public class IIDConstraint extends ThingConstraint {
     }
 
     @Override
-    public IIDConstraint clone(Conjunction.Cloner cloner) {
+    public IIDConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).iid(iid);
     }
 }

--- a/pattern/constraint/thing/IsConstraint.java
+++ b/pattern/constraint/thing/IsConstraint.java
@@ -89,7 +89,7 @@ public class IsConstraint extends ThingConstraint {
     }
 
     @Override
-    public IsConstraint clone(Conjunction.Cloner cloner) {
+    public IsConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).is(cloner.cloneVariable(variable));
     }
 }

--- a/pattern/constraint/thing/IsaConstraint.java
+++ b/pattern/constraint/thing/IsaConstraint.java
@@ -113,7 +113,7 @@ public class IsaConstraint extends ThingConstraint implements AlphaEquivalent<Is
     }
 
     @Override
-    public IsaConstraint clone(Conjunction.Cloner cloner) {
+    public IsaConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).isa(cloner.cloneVariable(type), isExplicit);
     }
 }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -97,6 +97,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
                 traversal.relating(owner.id(), role);
                 traversal.playing(player.id(), role);
                 traversal.isa(role, rolePlayer.roleType().get().id());
+                traversal.types(role, rolePlayer.inferredRoleTypes());
             } else {
                 traversal.rolePlayer(owner.id(), player.id(), rolePlayer.inferredRoleTypes(), rep);
             }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -219,7 +219,6 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             RolePlayer that = (RolePlayer) o;
             return (Objects.equals(this.roleType, that.roleType) &&
                     this.player.equals(that.player) &&
-                    Objects.equals(this.inferredRoleTypes, that.inferredRoleTypes) &&
                     this.repetition == that.repetition);
         }
 

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -158,7 +158,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         private final ThingVariable player;
         private final int repetition;
         private final int hash;
-        private Set<Label> inferredRoleTypes;
+        private final Set<Label> inferredRoleTypes;
 
         public RolePlayer(@Nullable TypeVariable roleType, ThingVariable player, int repetition) {
             assert roleType == null || roleType.id().isName() ||
@@ -166,7 +166,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             if (player == null) throw new NullPointerException("Null player");
             this.roleType = roleType;
             this.player = player;
-            this.inferredRoleTypes = null;
+            this.inferredRoleTypes = new HashSet<>();
             this.repetition = repetition;
             this.hash = Objects.hash(this.roleType, this.player, this.repetition);
         }
@@ -186,7 +186,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
                     cloner.clone(clone.player()),
                     clone.repetition()
             );
-            if (clone.roleType().isEmpty()) rolePlayer.setInferredRoleTypes(clone.inferredRoleTypes);
+            rolePlayer.setInferredRoleTypes(clone.inferredRoleTypes);
             return rolePlayer;
         }
 
@@ -199,14 +199,13 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         }
 
         public Set<Label> inferredRoleTypes() {
-            assert inferredRoleTypes != null ^ roleType != null;
-            if (inferredRoleTypes == null) return roleType.inferredTypes();
-            else return inferredRoleTypes;
+            assert !inferredRoleTypes.isEmpty();
+            return inferredRoleTypes;
         }
 
         public void setInferredRoleTypes(Set<Label> roleTypes) {
-            assert roleType == null;
-            this.inferredRoleTypes = set(roleTypes);
+            this.inferredRoleTypes.clear();
+            this.inferredRoleTypes.addAll(roleTypes);
         }
 
         public ThingVariable player() {
@@ -220,6 +219,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             RolePlayer that = (RolePlayer) o;
             return (Objects.equals(this.roleType, that.roleType) &&
                     this.player.equals(that.player) &&
+                    Objects.equals(this.inferredRoleTypes, that.inferredRoleTypes) &&
                     this.repetition == that.repetition);
         }
 
@@ -241,11 +241,11 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         }
 
         public RolePlayer clone(Conjunction.Cloner cloner) {
-            assert roleType != null ^ inferredRoleTypes != null;
+            assert inferredRoleTypes.isEmpty();
             TypeVariable roleTypeClone = roleType == null ? null : cloner.cloneVariable(roleType);
             ThingVariable playerClone = cloner.cloneVariable(player);
             RolePlayer rpClone = new RolePlayer(roleTypeClone, playerClone, repetition);
-            if (roleType().isEmpty()) rpClone.setInferredRoleTypes(this.inferredRoleTypes);
+            rpClone.setInferredRoleTypes(this.inferredRoleTypes);
             return rpClone;
         }
     }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -78,7 +78,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
     }
 
     @Override
-    public RelationConstraint clone(Conjunction.Cloner cloner) {
+    public RelationConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner()).relation(Iterators.iterate(rolePlayers).map(
                 rolePlayer -> rolePlayer.clone(cloner)).toLinkedSet());
     }
@@ -239,7 +239,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
                     .validIfAlphaEqual(player, that.player);
         }
 
-        public RolePlayer clone(Conjunction.Cloner cloner) {
+        public RolePlayer clone(Conjunction.ConstraintCloner cloner) {
             assert !inferredRoleTypes.isEmpty();
             TypeVariable roleTypeClone = roleType == null ? null : cloner.cloneVariable(roleType);
             ThingVariable playerClone = cloner.cloneVariable(player);

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -240,7 +240,6 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         }
 
         public RolePlayer clone(Conjunction.ConstraintCloner cloner) {
-            assert !inferredRoleTypes.isEmpty();
             TypeVariable roleTypeClone = roleType == null ? null : cloner.cloneVariable(roleType);
             ThingVariable playerClone = cloner.cloneVariable(player);
             RolePlayer rpClone = new RolePlayer(roleTypeClone, playerClone, repetition);

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -241,7 +241,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         }
 
         public RolePlayer clone(Conjunction.Cloner cloner) {
-            assert inferredRoleTypes.isEmpty();
+            assert !inferredRoleTypes.isEmpty();
             TypeVariable roleTypeClone = roleType == null ? null : cloner.cloneVariable(roleType);
             ThingVariable playerClone = cloner.cloneVariable(player);
             RolePlayer rpClone = new RolePlayer(roleTypeClone, playerClone, repetition);

--- a/pattern/constraint/thing/ValueConstraint.java
+++ b/pattern/constraint/thing/ValueConstraint.java
@@ -225,7 +225,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public Long clone(Conjunction.Cloner cloner) {
+        public Long clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueLong(predicate(), value);
         }
     }
@@ -257,7 +257,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public Double clone(Conjunction.Cloner cloner) {
+        public Double clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueDouble(predicate(), value);
         }
     }
@@ -289,7 +289,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public Boolean clone(Conjunction.Cloner cloner) {
+        public Boolean clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueBoolean(predicate(), value);
         }
     }
@@ -321,7 +321,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public String clone(Conjunction.Cloner cloner) {
+        public String clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueString(predicate(), value);
         }
     }
@@ -353,7 +353,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public DateTime clone(Conjunction.Cloner cloner) {
+        public DateTime clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueDateTime(predicate(), value);
         }
     }
@@ -398,7 +398,7 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         }
 
         @Override
-        public Variable clone(Conjunction.Cloner cloner) {
+        public Variable clone(Conjunction.ConstraintCloner cloner) {
             return cloner.cloneVariable(owner).valueVariable(predicate(), cloner.cloneVariable(value));
         }
     }

--- a/pattern/constraint/type/AbstractConstraint.java
+++ b/pattern/constraint/type/AbstractConstraint.java
@@ -76,7 +76,7 @@ public class AbstractConstraint extends TypeConstraint {
     }
 
     @Override
-    public AbstractConstraint clone(Conjunction.Cloner cloner) {
+    public AbstractConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).setAbstract();
     }
 }

--- a/pattern/constraint/type/IsConstraint.java
+++ b/pattern/constraint/type/IsConstraint.java
@@ -89,7 +89,7 @@ public class IsConstraint extends TypeConstraint {
     }
 
     @Override
-    public IsConstraint clone(Conjunction.Cloner cloner) {
+    public IsConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).is(cloner.cloneVariable(variable));
     }
 }

--- a/pattern/constraint/type/LabelConstraint.java
+++ b/pattern/constraint/type/LabelConstraint.java
@@ -107,7 +107,7 @@ public class LabelConstraint extends TypeConstraint implements AlphaEquivalent<L
     }
 
     @Override
-    public LabelConstraint clone(Conjunction.Cloner cloner) {
+    public LabelConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).label(label);
     }
 }

--- a/pattern/constraint/type/OwnsConstraint.java
+++ b/pattern/constraint/type/OwnsConstraint.java
@@ -121,7 +121,7 @@ public class OwnsConstraint extends TypeConstraint {
     }
 
     @Override
-    public OwnsConstraint clone(Conjunction.Cloner cloner) {
+    public OwnsConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).owns(
                 cloner.cloneVariable(attributeType),
                 overriddenAttributeType == null ? null : cloner.cloneVariable(overriddenAttributeType),

--- a/pattern/constraint/type/PlaysConstraint.java
+++ b/pattern/constraint/type/PlaysConstraint.java
@@ -125,7 +125,7 @@ public class PlaysConstraint extends TypeConstraint {
     }
 
     @Override
-    public PlaysConstraint clone(Conjunction.Cloner cloner) {
+    public PlaysConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).plays(
                 relationType == null ? null : cloner.cloneVariable(relationType),
                 cloner.cloneVariable(roleType),

--- a/pattern/constraint/type/RegexConstraint.java
+++ b/pattern/constraint/type/RegexConstraint.java
@@ -85,7 +85,7 @@ public class RegexConstraint extends TypeConstraint {
     }
 
     @Override
-    public RegexConstraint clone(Conjunction.Cloner cloner) {
+    public RegexConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).regex(regex);
     }
 }

--- a/pattern/constraint/type/RelatesConstraint.java
+++ b/pattern/constraint/type/RelatesConstraint.java
@@ -115,7 +115,7 @@ public class RelatesConstraint extends TypeConstraint {
     }
 
     @Override
-    public RelatesConstraint clone(Conjunction.Cloner cloner) {
+    public RelatesConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).relates(
                 cloner.cloneVariable(roleType),
                 overriddenRoleType == null ? null : cloner.cloneVariable(overriddenRoleType)

--- a/pattern/constraint/type/SubConstraint.java
+++ b/pattern/constraint/type/SubConstraint.java
@@ -105,7 +105,7 @@ public class SubConstraint extends TypeConstraint {
     }
 
     @Override
-    public SubConstraint clone(Conjunction.Cloner cloner) {
+    public SubConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).sub(cloner.cloneVariable(type), isExplicit);
     }
 }

--- a/pattern/constraint/type/ValueTypeConstraint.java
+++ b/pattern/constraint/type/ValueTypeConstraint.java
@@ -94,7 +94,7 @@ public class ValueTypeConstraint extends TypeConstraint implements AlphaEquivale
     }
 
     @Override
-    public ValueTypeConstraint clone(Conjunction.Cloner cloner) {
+    public ValueTypeConstraint clone(Conjunction.ConstraintCloner cloner) {
         return cloner.cloneVariable(owner).valueType(valueType);
     }
 }

--- a/pattern/variable/VariableCloner.java
+++ b/pattern/variable/VariableCloner.java
@@ -51,7 +51,9 @@ public class VariableCloner {
 
     public ThingVariable clone(ThingVariable variable) {
         assert variable.id().isVariable();
-        ThingVariable newClone = variables.computeIfAbsent(variable.id().asVariable(), ThingVariable::new).asThing();
+        if (variables.containsKey(variable.id())) return variables.get(variable.id()).asThing();
+        ThingVariable newClone = new ThingVariable(variable.id());
+        variables.put(variable.id(), newClone);
         newClone.setInferredTypes(variable.inferredTypes());
         newClone.constrainClone(variable, this);
         return newClone;
@@ -59,7 +61,9 @@ public class VariableCloner {
 
     public TypeVariable clone(TypeVariable variable) {
         assert variable.id().isVariable();
-        TypeVariable newClone = variables.computeIfAbsent(variable.id().asVariable(), TypeVariable::new).asType();
+        if (variables.containsKey(variable.id())) return variables.get(variable.id()).asType();
+        TypeVariable newClone = new TypeVariable(variable.id());
+        variables.put(variable.id(), newClone);
         newClone.setInferredTypes(variable.inferredTypes());
         newClone.constrainClone(variable, this);
         return newClone;

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -491,7 +491,7 @@ public class TypeInferenceTest {
             put("$role", set("hetero-marriage:husband", "marriage:spouse", "partnership:partner", "relation:role"));
             put("$r", set("hetero-marriage", "marriage"));
             put("$m", set("hetero-marriage", "marriage", "partnership", "relation", "thing"));
-            put("$_relation:spouse", set("marriage:spouse"));
+            put("$_relation:spouse", set("marriage:spouse", "hetero-marriage:wife", "hetero-marriage:husband"));
             put("$_man", set("man"));
         }};
 
@@ -899,7 +899,7 @@ public class TypeInferenceTest {
             put("$x", set("person"));
             put("$y", set("person"));
             put("$m", set("marriage", "hetero-marriage"));
-            put("$_marriage:spouse", set("marriage:spouse"));
+            put("$_marriage:spouse", set("marriage:spouse", "hetero-marriage:husband", "hetero-marriage:wife"));
             put("$_marriage", set("marriage"));
         }};
         assertEquals(expected, resolvedTypeMap(disjunction.conjunctions().get(0)));

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -491,7 +491,7 @@ public class TypeInferenceTest {
             put("$role", set("hetero-marriage:husband", "marriage:spouse", "partnership:partner", "relation:role"));
             put("$r", set("hetero-marriage", "marriage"));
             put("$m", set("hetero-marriage", "marriage", "partnership", "relation", "thing"));
-            put("$_relation:spouse", set("marriage:spouse", "hetero-marriage:wife", "hetero-marriage:husband"));
+            put("$_relation:spouse", set("marriage:spouse"));
             put("$_man", set("man"));
         }};
 
@@ -899,7 +899,7 @@ public class TypeInferenceTest {
             put("$x", set("person"));
             put("$y", set("person"));
             put("$m", set("marriage", "hetero-marriage"));
-            put("$_marriage:spouse", set("marriage:spouse", "hetero-marriage:husband", "hetero-marriage:wife"));
+            put("$_marriage:spouse", set("marriage:spouse"));
             put("$_marriage", set("marriage"));
         }};
         assertEquals(expected, resolvedTypeMap(disjunction.conjunctions().get(0)));

--- a/test/integration/traversal/TraversalTest.java
+++ b/test/integration/traversal/TraversalTest.java
@@ -179,7 +179,6 @@ public class TraversalTest {
             TypeQLDefine query = TypeQL.parseQuery("define " +
                     "lastname sub attribute, value string; " +
                     "person sub entity, owns lastname; "
-
             );
             transaction.query().define(query);
             transaction.commit();
@@ -221,9 +220,11 @@ public class TraversalTest {
 
             ProcedureVertex.Thing _0 = proc.anonymousThing(0);
             _0.props().predicate(Predicate.Value.String.of(TypeQLToken.Predicate.Equality.EQ));
+            _0.props().types(set(Label.of("name")));
 
             ProcedureVertex.Thing _1 = proc.anonymousThing(1);
             _1.props().predicate(Predicate.Value.String.of(TypeQLToken.Predicate.Equality.EQ));
+            _1.props().types(set(Label.of("name")));
 
             ProcedureVertex.Thing f1 = proc.namedThing("f1");
             f1.props().types(set(Label.of("friendship")));
@@ -236,9 +237,11 @@ public class TraversalTest {
 
             ProcedureVertex.Thing r1 = proc.namedThing("r1");
             r1.props().predicate(Predicate.Value.Numerical.of(TypeQLToken.Predicate.Equality.EQ, PredicateArgument.Value.LONG));
+            r1.props().types(set(Label.of("ref")));
 
             ProcedureVertex.Thing r2 = proc.namedThing("r2");
             r2.props().predicate(Predicate.Value.Numerical.of(TypeQLToken.Predicate.Equality.EQ, PredicateArgument.Value.LONG));
+            r2.props().types(set(Label.of("ref")));
 
             ProcedureVertex.Thing x = proc.namedThing("x");
             x.props().types(set(Label.of("person")));

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -532,6 +532,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                         cost = 1;
                     } else {
                         Set<Label> toTypes = to.props().types();
+                        // TODO: should this calculate the average rather than max?
                         if (!isTransitive) cost = graphMgr.data().stats().thingVertexMax(toTypes);
                         else cost = graphMgr.data().stats().thingVertexTransitiveMax(toTypes);
                     }
@@ -1308,6 +1309,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             setObjectiveCoefficient(1);
                             return;
                         }
+
                         double cost = 0;
                         double div = graphMgr.data().stats().thingVertexSum(from.props().types());
                         if (div > 0) cost = graphMgr.data().stats().thingVertexSum(roleTypes) / div;

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -227,23 +227,12 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         void updateObjective(GraphManager graph) {
             if (props().hasIID()) {
                 setObjectiveCoefficient(1);
-            } else if (!props().types().isEmpty()) {
+            } else {
                 if (iterate(props().predicates()).anyMatch(p -> p.operator().equals(EQ))) {
                     setObjectiveCoefficient(props().types().size());
                 } else {
                     setObjectiveCoefficient(graph.data().stats().thingVertexSum(props().types()));
                 }
-            } else if (!props().predicates().isEmpty()) {
-                FunctionalIterator<TypeVertex> attTypes = iterate(props().predicates())
-                        .flatMap(p -> iterate(p.valueType().comparables()))
-                        .flatMap(vt -> graph.schema().attributeTypes(vt));
-                if (iterate(props().predicates()).anyMatch(p -> p.operator().equals(EQ))) {
-                    setObjectiveCoefficient(attTypes.count());
-                } else {
-                    setObjectiveCoefficient(graph.data().stats().thingVertexSum(attTypes.stream()));
-                }
-            } else {
-                setObjectiveCoefficient(graph.data().stats().thingVertexTransitiveCount(graph.schema().rootThingType()));
             }
         }
 

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -228,6 +228,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
             if (props().hasIID()) {
                 setObjectiveCoefficient(1);
             } else {
+                assert !props().types().isEmpty();
                 if (iterate(props().predicates()).anyMatch(p -> p.operator().equals(EQ))) {
                     setObjectiveCoefficient(props().types().size());
                 } else {

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -1276,13 +1276,13 @@ public abstract class ProcedureEdge<
                         Seekable<KeyValue<ThingVertex, ThingVertex>, Order.Asc> iter;
                         boolean filteredIID = false, filteredTypes = false;
 
-                        FunctionalIterator<TypeVertex> resolveRoleTypesIter = iterate(roleTypes).map(graphMgr.schema()::getType);
+                        FunctionalIterator<TypeVertex> roleTypeVertices = iterate(roleTypes).map(graphMgr.schema()::getType);
                         if (to.props().hasIID()) {
                             assert to.id().isVariable();
                             filteredIID = true;
                             ThingVertex relation = graphMgr.data().getReadable(params.getIID(to.id().asVariable()));
                             if (relation == null) return emptySorted();
-                            iter = resolveRoleTypesIter.mergeMap(
+                            iter = roleTypeVertices.mergeMap(
                                     ASC,
                                     rt -> player.ins()
                                             .edge(ROLEPLAYER, rt, relation.iid().prefix(), relation.iid().type())
@@ -1290,7 +1290,7 @@ public abstract class ProcedureEdge<
                             );
                         } else {
                             filteredTypes = true;
-                            iter = resolveRoleTypesIter.mergeMap(
+                            iter = roleTypeVertices.mergeMap(
                                     ASC,
                                     rt -> iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).noNulls()
                                             .mergeMap(ASC, t -> player.ins()

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -151,69 +151,15 @@ public abstract class ProcedureVertex<
         public Seekable<? extends ThingVertex, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters) {
             assert isStartingVertex();
             if (props().hasIID()) return iterateAndFilterFromIID(graphMgr, parameters);
-            else if (!props().types().isEmpty()) return iterateAndFilterFromTypes(graphMgr, parameters);
-            else if (mustBeAttribute()) return iterateAndFilterFromAttributes(graphMgr, parameters);
-            else if (mustBeRelation()) return iterateFromAll(graphMgr, graphMgr.schema().rootRelationType());
-            else if (mustBeRole()) return iterateFromAll(graphMgr, graphMgr.schema().rootRoleType());
-            else if (mustBeThing()) return iterateFromAll(graphMgr, graphMgr.schema().rootThingType());
-            else throw TypeDBException.of(ILLEGAL_STATE);
+            else return iterateAndFilterFromTypes(graphMgr, parameters);
         }
 
         Seekable<? extends ThingVertex, Order.Asc> filter(Seekable<? extends ThingVertex, Order.Asc> iterator,
                                                           Traversal.Parameters params) {
+            iterator = filterTypes(iterator);
             if (props().hasIID()) iterator = filterIID(iterator, params);
-            if (!props().types().isEmpty()) iterator = filterTypes(iterator);
             if (!props().predicates().isEmpty()) iterator = filterPredicates(filterAttributes(iterator), params);
             return iterator;
-        }
-
-        private boolean mustBeAttribute() {
-            return !props().predicates().isEmpty() || iterate(outs()).anyMatch(ProcedureEdge::onlyStartsFromAttribute);
-        }
-
-        private boolean mustBeRelation() {
-            return iterate(outs()).anyMatch(ProcedureEdge::onlyStartsFromRelation);
-        }
-
-        private boolean mustBeRole() {
-            return id().isScoped();
-        }
-
-        private boolean mustBeThing() {
-            return id().isVariable();
-        }
-
-        private Seekable<? extends ThingVertex, Order.Asc> iterateAndFilterFromAttributes(
-                GraphManager graph, Traversal.Parameters parameters) {
-            Seekable<? extends AttributeVertex<?>, Order.Asc> iter;
-            FunctionalIterator<TypeVertex> attTypes;
-
-            Optional<Predicate.Value<?>> eq = iterate(props().predicates()).filter(p -> p.operator().equals(EQ)).first();
-
-            if (eq.isPresent()) {
-                attTypes = iterate(eq.get().valueType().assignables())
-                        .flatMap(vt -> graph.schema().attributeTypes(vt));
-                iter = iteratorOfAttributes(graph, attTypes, parameters, eq.get());
-            } else {
-                if (!props().predicates().isEmpty()) {
-                    attTypes = iterate(props().predicates())
-                            .flatMap(p -> iterate(p.valueType().comparables()))
-                            .flatMap(vt -> graph.schema().attributeTypes(vt));
-                } else {
-                    // TODO should read from cache
-                    attTypes = tree(graph.schema().rootAttributeType(), a -> a.ins().edge(SUB).from());
-                }
-                iter = attTypes.mergeMap(ASC, t -> graph.data().getReadable(t))
-                        .mapSorted(ASC, ThingVertex::asAttribute, v -> v);
-            }
-
-            if (props().predicates().isEmpty()) return iter;
-            else return filterPredicates(iter, parameters, eq.orElse(null));
-        }
-
-        private Seekable<ThingVertex, Order.Asc> iterateFromAll(GraphManager graphMgr, TypeVertex rootType) {
-            // TODO should read from cache
-            return iterate(tree(rootType, t -> t.ins().edge(SUB).from())).mergeMap(ASC, t -> graphMgr.data().getReadable(t));
         }
 
         Seekable<? extends ThingVertex, Order.Asc> iterateAndFilterFromIID(GraphManager graphMgr, Traversal.Parameters parameters) {
@@ -221,15 +167,13 @@ public abstract class ProcedureVertex<
             Identifier.Variable id = id().asVariable();
             ThingVertex vertex = graphMgr.data().getReadable(parameters.getIID(id));
             if (vertex == null) return emptySorted();
-            Seekable<? extends ThingVertex, Order.Asc> iter = iterateSorted(ASC, vertex);
-            if (!props().types().isEmpty()) iter = filterTypes(iter);
+            Seekable<? extends ThingVertex, Order.Asc> iter = filterTypes(iterateSorted(ASC, vertex));
             if (!props().predicates().isEmpty()) iter = filterPredicates(filterAttributes(iter), parameters);
             return iter;
         }
 
         Seekable<? extends ThingVertex, Order.Asc> iterateAndFilterFromTypes(GraphManager graphMgr,
                                                                              Traversal.Parameters parameters) {
-            assert !props().types().isEmpty();
             Seekable<? extends ThingVertex, Order.Asc> iter;
             Optional<Predicate.Value<?>> eq = iterate(props().predicates()).filter(p -> p.operator().equals(EQ)).first();
             if (eq.isPresent()) iter = iteratorOfAttributesWithTypes(graphMgr, parameters, eq.get());
@@ -241,7 +185,10 @@ public abstract class ProcedureVertex<
             }
 
             if (props().predicates().isEmpty()) return iter;
-            else return filterPredicates(filterAttributes(iter), parameters, eq.orElse(null));
+            else {
+                // TODO we shouldn't need to filter attributes since the type iterator should already filter in attribute types only to start with.
+                return filterPredicates(filterAttributes(iter), parameters, eq.orElse(null));
+            }
         }
 
         Seekable<? extends ThingVertex, Order.Asc> filterIID(Seekable<? extends ThingVertex, Order.Asc> iterator,

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -163,7 +163,7 @@ public abstract class ProcedureVertex<
         }
 
         Seekable<? extends ThingVertex, Order.Asc> iterateAndFilterFromIID(GraphManager graphMgr, Traversal.Parameters parameters) {
-            assert props().hasIID() && id().isVariable();
+            assert props().hasIID() && id().isVariable() && !props().types().isEmpty();
             Identifier.Variable id = id().asVariable();
             ThingVertex vertex = graphMgr.data().getReadable(parameters.getIID(id));
             if (vertex == null) return emptySorted();
@@ -174,6 +174,7 @@ public abstract class ProcedureVertex<
 
         Seekable<? extends ThingVertex, Order.Asc> iterateAndFilterFromTypes(GraphManager graphMgr,
                                                                              Traversal.Parameters parameters) {
+            assert !props().types().isEmpty();
             Seekable<? extends ThingVertex, Order.Asc> iter;
             Optional<Predicate.Value<?>> eq = iterate(props().predicates()).filter(p -> p.operator().equals(EQ)).first();
             if (eq.isPresent()) iter = iteratorOfAttributesWithTypes(graphMgr, parameters, eq.get());


### PR DESCRIPTION
## What is the goal of this PR?

We simplify and remove unneeded code branches that were created to handle the case where Type Inference has not run. We build in the assumption that all Thing vertices will have a set of possible types added via type inference (but not for Type vertices, which may not for schema-only queries). In the process we also move the responsibility of resolving role instance types from Planner/Procedure to Type Inference, where it should belong.

## What are the changes implemented in this PR?

* Delete Planner code paths that defended against nonexistent inferred types for Thing vertices, we now always assume there are a set of possible types populated
* Delete Procedure code paths that defended against nonexistent inferred types for Thing vertices, we now always assume there are a set of possible types populated
* Extract duplicated type inference for role instances from the Planner and Procedure to Type Inference, and pass the result into the traversal engine
* Add a new rule validation for ambiguous type labels (ie. roles) that should not be allowed in a rule conclusion. Consider `then { (role: $x) isa marriage;}` where the `role` could be either `husband` or `wife` - it is ambiguous
* Fix various tests following from these changes
* Rename `Conjunction.Cloner` to `Conjunction.ConstraintCloner` since it is used to clone a subset of conjunction constraints from the conjunction