### PR TITLE
Concept API exposes and uses seekable iterators

### DIFF
--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -25,7 +25,7 @@ import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 
-public interface Thing extends Concept {
+public interface Thing extends Concept, Comparable<Thing> {
 
     /**
      * Returns the {@code IID} of this {@code Thing} as a byte array.

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -77,7 +77,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
         }
     }
 
-    protected ThingVertex readableVertex() {
+    public ThingVertex readableVertex() {
         return vertex;
     }
 

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -286,4 +286,9 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
     public final int hashCode() {
         return readableVertex().hashCode(); // does not need caching
     }
+
+    @Override
+    public int compareTo(Thing other) {
+        return vertex.compareTo(((ThingImpl) other).vertex);
+    }
 }

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.core.concept.type;
 
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Attribute;

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -19,6 +19,8 @@
 package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Attribute;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typeql.lang.common.TypeQLArg;
@@ -33,16 +35,16 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 public interface AttributeType extends ThingType {
 
     @Override
-    FunctionalIterator<? extends AttributeType> getSubtypes();
+    Seekable<? extends AttributeType, Order.Asc> getSubtypes();
 
     @Override
-    FunctionalIterator<? extends AttributeType> getSubtypesExplicit();
+    Seekable<? extends AttributeType, Order.Asc> getSubtypesExplicit();
 
     @Override
-    FunctionalIterator<? extends Attribute> getInstances();
+    Seekable<? extends Attribute, Order.Asc> getInstances();
 
     @Override
-    FunctionalIterator<? extends Attribute> getInstancesExplicit();
+    Seekable<? extends Attribute, Order.Asc> getInstancesExplicit();
 
     void setSupertype(AttributeType superType);
 
@@ -50,9 +52,9 @@ public interface AttributeType extends ThingType {
 
     ValueType getValueType();
 
-    FunctionalIterator<? extends ThingType> getOwners();
+    Seekable<? extends ThingType, Order.Asc> getOwners();
 
-    FunctionalIterator<? extends ThingType> getOwners(boolean onlyKey);
+    Seekable<? extends ThingType, Order.Asc> getOwners(boolean onlyKey);
 
     boolean isBoolean();
 
@@ -144,16 +146,16 @@ public interface AttributeType extends ThingType {
     interface Boolean extends AttributeType {
 
         @Override
-        FunctionalIterator<? extends AttributeType.Boolean> getSubtypes();
+        Seekable<? extends AttributeType.Boolean, Order.Asc> getSubtypes();
 
         @Override
-        FunctionalIterator<? extends AttributeType.Boolean> getSubtypesExplicit();
+        Seekable<? extends AttributeType.Boolean, Order.Asc> getSubtypesExplicit();
 
         @Override
-        FunctionalIterator<? extends Attribute.Boolean> getInstances();
+        Seekable<? extends Attribute.Boolean, Order.Asc> getInstances();
 
         @Override
-        FunctionalIterator<? extends Attribute.Boolean> getInstancesExplicit();
+        Seekable<? extends Attribute.Boolean, Order.Asc> getInstancesExplicit();
 
         Attribute.Boolean put(boolean value);
 
@@ -165,16 +167,16 @@ public interface AttributeType extends ThingType {
     interface Long extends AttributeType {
 
         @Override
-        FunctionalIterator<? extends AttributeType.Long> getSubtypes();
+        Seekable<? extends AttributeType.Long, Order.Asc> getSubtypes();
 
         @Override
-        FunctionalIterator<? extends AttributeType.Long> getSubtypesExplicit();
+        Seekable<? extends AttributeType.Long, Order.Asc> getSubtypesExplicit();
 
         @Override
-        FunctionalIterator<? extends Attribute.Long> getInstances();
+        Seekable<? extends Attribute.Long, Order.Asc> getInstances();
 
         @Override
-        FunctionalIterator<? extends Attribute.Long> getInstancesExplicit();
+        Seekable<? extends Attribute.Long, Order.Asc> getInstancesExplicit();
 
         Attribute.Long put(long value);
 
@@ -186,16 +188,16 @@ public interface AttributeType extends ThingType {
     interface Double extends AttributeType {
 
         @Override
-        FunctionalIterator<? extends AttributeType.Double> getSubtypes();
+        Seekable<? extends AttributeType.Double, Order.Asc> getSubtypes();
 
         @Override
-        FunctionalIterator<? extends AttributeType.Double> getSubtypesExplicit();
+        Seekable<? extends AttributeType.Double, Order.Asc> getSubtypesExplicit();
 
         @Override
-        FunctionalIterator<? extends Attribute.Double> getInstances();
+        Seekable<? extends Attribute.Double, Order.Asc> getInstances();
 
         @Override
-        FunctionalIterator<? extends Attribute.Double> getInstancesExplicit();
+        Seekable<? extends Attribute.Double, Order.Asc> getInstancesExplicit();
 
         Attribute.Double put(double value);
 
@@ -207,16 +209,16 @@ public interface AttributeType extends ThingType {
     interface String extends AttributeType {
 
         @Override
-        FunctionalIterator<? extends AttributeType.String> getSubtypes();
+        Seekable<? extends AttributeType.String, Order.Asc> getSubtypes();
 
         @Override
-        FunctionalIterator<? extends AttributeType.String> getSubtypesExplicit();
+        Seekable<? extends AttributeType.String, Order.Asc> getSubtypesExplicit();
 
         @Override
-        FunctionalIterator<? extends Attribute.String> getInstances();
+        Seekable<? extends Attribute.String, Order.Asc> getInstances();
 
         @Override
-        FunctionalIterator<? extends Attribute.String> getInstancesExplicit();
+        Seekable<? extends Attribute.String, Order.Asc> getInstancesExplicit();
 
         void setRegex(Pattern regex);
 
@@ -234,16 +236,16 @@ public interface AttributeType extends ThingType {
     interface DateTime extends AttributeType {
 
         @Override
-        FunctionalIterator<? extends AttributeType.DateTime> getSubtypes();
+        Seekable<? extends AttributeType.DateTime, Order.Asc> getSubtypes();
 
         @Override
-        FunctionalIterator<? extends AttributeType.DateTime> getSubtypesExplicit();
+        Seekable<? extends AttributeType.DateTime, Order.Asc> getSubtypesExplicit();
 
         @Override
-        FunctionalIterator<? extends Attribute.DateTime> getInstances();
+        Seekable<? extends Attribute.DateTime, Order.Asc> getInstances();
 
         @Override
-        FunctionalIterator<? extends Attribute.DateTime> getInstancesExplicit();
+        Seekable<? extends Attribute.DateTime, Order.Asc> getInstancesExplicit();
 
         Attribute.DateTime put(LocalDateTime value);
 

--- a/concept/type/EntityType.java
+++ b/concept/type/EntityType.java
@@ -18,22 +18,23 @@
 
 package com.vaticle.typedb.core.concept.type;
 
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Entity;
 
 public interface EntityType extends ThingType {
 
     @Override
-    FunctionalIterator<? extends EntityType> getSubtypes();
+    Seekable<? extends EntityType, Order.Asc> getSubtypes();
 
     @Override
-    FunctionalIterator<? extends EntityType> getSubtypesExplicit();
+    Seekable<? extends EntityType, Order.Asc> getSubtypesExplicit();
 
     @Override
-    FunctionalIterator<? extends Entity> getInstances();
+    Seekable<? extends Entity, Order.Asc> getInstances();
 
     @Override
-    FunctionalIterator<? extends Entity> getInstancesExplicit();
+    Seekable<? extends Entity, Order.Asc> getInstancesExplicit();
 
     void setSupertype(EntityType superType);
 

--- a/concept/type/RelationType.java
+++ b/concept/type/RelationType.java
@@ -19,21 +19,24 @@
 package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Relation;
+
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order.Asc;
 
 public interface RelationType extends ThingType {
 
     @Override
-    FunctionalIterator<? extends RelationType> getSubtypes();
+    Seekable<? extends RelationType, Asc> getSubtypes();
 
     @Override
-    FunctionalIterator<? extends RelationType> getSubtypesExplicit();
+    Seekable<? extends RelationType, Asc> getSubtypesExplicit();
 
     @Override
-    FunctionalIterator<? extends Relation> getInstances();
+    Seekable<? extends Relation, Asc> getInstances();
 
     @Override
-    FunctionalIterator<? extends Relation> getInstancesExplicit();
+    Seekable<? extends Relation, Asc> getInstancesExplicit();
 
     void setSupertype(RelationType superType);
 

--- a/concept/type/RelationType.java
+++ b/concept/type/RelationType.java
@@ -18,8 +18,6 @@
 
 package com.vaticle.typedb.core.concept.type;
 
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Relation;

--- a/concept/type/RelationType.java
+++ b/concept/type/RelationType.java
@@ -19,24 +19,25 @@
 package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Relation;
 
-import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order.Asc;
 
 public interface RelationType extends ThingType {
 
     @Override
-    Seekable<? extends RelationType, Asc> getSubtypes();
+    Seekable<? extends RelationType, Order.Asc> getSubtypes();
 
     @Override
-    Seekable<? extends RelationType, Asc> getSubtypesExplicit();
+    Seekable<? extends RelationType, Order.Asc> getSubtypesExplicit();
 
     @Override
-    Seekable<? extends Relation, Asc> getInstances();
+    Seekable<? extends Relation, Order.Asc> getInstances();
 
     @Override
-    Seekable<? extends Relation, Asc> getInstancesExplicit();
+    Seekable<? extends Relation, Order.Asc> getInstancesExplicit();
 
     void setSupertype(RelationType superType);
 
@@ -46,9 +47,9 @@ public interface RelationType extends ThingType {
 
     void unsetRelates(String roleLabel);
 
-    FunctionalIterator<? extends RoleType> getRelates();
+    Seekable<? extends RoleType, Order.Asc> getRelates();
 
-    FunctionalIterator<? extends RoleType> getRelatesExplicit();
+    Seekable<? extends RoleType, Order.Asc> getRelatesExplicit();
 
     RoleType getRelates(String roleLabel);
 

--- a/concept/type/RoleType.java
+++ b/concept/type/RoleType.java
@@ -19,6 +19,8 @@
 package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 
 public interface RoleType extends Type {
 
@@ -29,14 +31,14 @@ public interface RoleType extends Type {
     FunctionalIterator<? extends RoleType> getSupertypes();
 
     @Override
-    FunctionalIterator<? extends RoleType> getSubtypes();
+    Seekable<? extends RoleType, Order.Asc> getSubtypes();
 
     @Override
-    FunctionalIterator<? extends RoleType> getSubtypesExplicit();
+    Seekable<? extends RoleType, Order.Asc> getSubtypesExplicit();
 
     RelationType getRelationType();
 
-    FunctionalIterator<? extends RelationType> getRelationTypes();
+    Seekable<? extends RelationType, Order.Asc> getRelationTypes();
 
-    FunctionalIterator<? extends ThingType> getPlayers();
+    Seekable<? extends ThingType, Order.Asc> getPlayers();
 }

--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -19,6 +19,8 @@
 package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Thing;
 
 public interface ThingType extends Type {
@@ -30,14 +32,14 @@ public interface ThingType extends Type {
     FunctionalIterator<? extends ThingType> getSupertypes();
 
     @Override
-    FunctionalIterator<? extends ThingType> getSubtypes();
+    Seekable<? extends ThingType, Order.Asc> getSubtypes();
 
     @Override
-    FunctionalIterator<? extends ThingType> getSubtypesExplicit();
+    Seekable<? extends ThingType, Order.Asc> getSubtypesExplicit();
 
-    FunctionalIterator<? extends Thing> getInstances();
+    Seekable<? extends Thing, Order.Asc> getInstances();
 
-    FunctionalIterator<? extends Thing> getInstancesExplicit();
+    Seekable<? extends Thing, Order.Asc> getInstancesExplicit();
 
     void setAbstract();
 
@@ -53,21 +55,21 @@ public interface ThingType extends Type {
 
     void unsetOwns(AttributeType attributeType);
 
-    FunctionalIterator<? extends AttributeType> getOwns();
+    Seekable<? extends AttributeType, Order.Asc> getOwns();
 
-    FunctionalIterator<? extends AttributeType> getOwnsExplicit();
+    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit();
 
-    FunctionalIterator<? extends AttributeType> getOwns(boolean onlyKey);
+    Seekable<? extends AttributeType, Order.Asc> getOwns(boolean onlyKey);
 
-    FunctionalIterator<? extends AttributeType> getOwnsExplicit(boolean onlyKey);
+    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(boolean onlyKey);
 
-    FunctionalIterator<? extends AttributeType> getOwns(AttributeType.ValueType valueType);
+    Seekable<? extends AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType);
 
-    FunctionalIterator<? extends AttributeType> getOwnsExplicit(AttributeType.ValueType valueType);
+    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType);
 
-    FunctionalIterator<? extends AttributeType> getOwns(AttributeType.ValueType valueType, boolean onlyKey);
+    Seekable<? extends AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType, boolean onlyKey);
 
-    FunctionalIterator<? extends AttributeType> getOwnsExplicit(AttributeType.ValueType valueType, boolean onlyKey);
+    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType, boolean onlyKey);
 
     AttributeType getOwnsOverridden(AttributeType attributeType);
 
@@ -77,9 +79,9 @@ public interface ThingType extends Type {
 
     void unsetPlays(RoleType roleType);
 
-    FunctionalIterator<? extends RoleType> getPlays();
+    Seekable<? extends RoleType, Order.Asc> getPlays();
 
-    FunctionalIterator<? extends RoleType> getPlaysExplicit();
+    Seekable<? extends RoleType, Order.Asc> getPlaysExplicit();
 
     RoleType getPlaysOverridden(RoleType roleType);
 }

--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -55,21 +55,21 @@ public interface ThingType extends Type {
 
     void unsetOwns(AttributeType attributeType);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwns();
+    Seekable<AttributeType, Order.Asc> getOwns();
 
-    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit();
+    Seekable<AttributeType, Order.Asc> getOwnsExplicit();
 
-    Seekable<? extends AttributeType, Order.Asc> getOwns(boolean onlyKey);
+    Seekable<AttributeType, Order.Asc> getOwns(boolean onlyKey);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(boolean onlyKey);
+    Seekable<AttributeType, Order.Asc> getOwnsExplicit(boolean onlyKey);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType);
+    Seekable<AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType);
+    Seekable<AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType, boolean onlyKey);
+    Seekable<AttributeType, Order.Asc> getOwns(AttributeType.ValueType valueType, boolean onlyKey);
 
-    Seekable<? extends AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType, boolean onlyKey);
+    Seekable<AttributeType, Order.Asc> getOwnsExplicit(AttributeType.ValueType valueType, boolean onlyKey);
 
     AttributeType getOwnsOverridden(AttributeType attributeType);
 
@@ -79,9 +79,9 @@ public interface ThingType extends Type {
 
     void unsetPlays(RoleType roleType);
 
-    Seekable<? extends RoleType, Order.Asc> getPlays();
+    Seekable<RoleType, Order.Asc> getPlays();
 
-    Seekable<? extends RoleType, Order.Asc> getPlaysExplicit();
+    Seekable<RoleType, Order.Asc> getPlaysExplicit();
 
     RoleType getPlaysOverridden(RoleType roleType);
 }

--- a/concept/type/Type.java
+++ b/concept/type/Type.java
@@ -20,12 +20,14 @@ package com.vaticle.typedb.core.concept.type;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concept.Concept;
 
 import java.util.List;
 
-public interface Type extends Concept {
+public interface Type extends Concept, Comparable<Type> {
 
     long getInstancesCount();
 
@@ -41,9 +43,9 @@ public interface Type extends Concept {
 
     FunctionalIterator<? extends Type> getSupertypes();
 
-    FunctionalIterator<? extends Type> getSubtypes();
+    Seekable<? extends Type, Order.Asc> getSubtypes();
 
-    FunctionalIterator<? extends Type> getSubtypesExplicit();
+    Seekable<? extends Type, Order.Asc> getSubtypesExplicit();
 
     List<TypeDBException> validate();
 }

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -159,19 +159,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
     @Override
     public Seekable<? extends ThingTypeImpl, Order.Asc> getOwners(boolean onlyKey) {
         if (isRoot()) return emptySorted();
-        return directOwners(onlyKey)
-                .mergeMap(ThingTypeImpl::getSubtypes, ASC)
-                .filter(t -> t.overriddenOwns(onlyKey, true).noneMatch(o -> o.equals(this)));
-    }
-
-    private Seekable<? extends ThingTypeImpl, Order.Asc> directOwners(boolean onlyKey) {
-        if (isRoot()) return emptySorted();
-
-        if (onlyKey) {
-            return vertex.ins().edge(OWNS_KEY).from().mapSorted(v -> ThingTypeImpl.of(graphMgr, v), t -> t.vertex, ASC);
+        else if (onlyKey) {
+            return iterateSorted(graphMgr.schema().ownersOfKeyAttributeType(vertex), ASC)
+                    .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), thingType -> thingType.vertex, ASC);
         } else {
-            return vertex.ins().edge(OWNS_KEY).from().merge(vertex.ins().edge(OWNS).from())
-                    .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), t -> t.vertex, ASC);
+            return iterateSorted(graphMgr.schema().ownersOfAttributeType(vertex), ASC)
+                    .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), thingType -> thingType.vertex, ASC);
         }
     }
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -19,13 +19,9 @@
 package com.vaticle.typedb.core.concept.type.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Attribute;
-import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.thing.impl.AttributeImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RoleType;
@@ -51,16 +47,10 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.AT
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_SUPERTYPE_VALUE_TYPE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_UNSET_ABSTRACT_HAS_SUBTYPES;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.merge;
-import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
-import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
-import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS;
-import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS_KEY;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.SUB;
 import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.BOOLEAN;
 import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.DATETIME;

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -54,6 +54,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.RO
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.emptySorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.merge;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
@@ -476,8 +477,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
             @Override
             public Seekable<AttributeTypeImpl.Boolean, Order.Asc> getSubtypes() {
-                return super.getSubtypeVertices(BOOLEAN)
-                        .mapSorted(v -> AttributeTypeImpl.Boolean.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+                return merge(
+                        iterateSorted(ASC, this),
+                        super.getSubtypeVertices(BOOLEAN).mapSorted(v ->
+                                AttributeTypeImpl.Boolean.of(graphMgr, v), attrType -> attrType.vertex, ASC
+                        )
+                );
             }
 
             @Override
@@ -617,8 +622,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
             @Override
             public Seekable<AttributeTypeImpl.Long, Order.Asc> getSubtypes() {
-                return super.getSubtypeVertices(LONG)
-                        .mapSorted(v -> AttributeTypeImpl.Long.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+                return merge(
+                        iterateSorted(ASC, this),
+                        super.getSubtypeVertices(LONG).mapSorted(v ->
+                                AttributeTypeImpl.Long.of(graphMgr, v), attrType -> attrType.vertex, ASC
+                        )
+                );
             }
 
             @Override
@@ -758,8 +767,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
             @Override
             public Seekable<AttributeTypeImpl.Double, Order.Asc> getSubtypes() {
-                return super.getSubtypeVertices(DOUBLE)
-                        .mapSorted(v -> AttributeTypeImpl.Double.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+                return merge(
+                        iterateSorted(ASC, this),
+                        super.getSubtypeVertices(DOUBLE).mapSorted(v ->
+                                AttributeTypeImpl.Double.of(graphMgr, v), attrType -> attrType.vertex, ASC
+                        )
+                );
             }
 
             @Override
@@ -928,8 +941,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
             @Override
             public Seekable<AttributeTypeImpl.String, Order.Asc> getSubtypes() {
-                return super.getSubtypeVertices(STRING)
-                        .mapSorted(v -> AttributeTypeImpl.String.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+                return merge(
+                        iterateSorted(ASC, this),
+                        super.getSubtypeVertices(STRING).mapSorted(v ->
+                                AttributeTypeImpl.String.of(graphMgr, v), attrType -> attrType.vertex, ASC
+                        )
+                );
             }
 
             @Override
@@ -1079,9 +1096,12 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
             @Override
             public Seekable<AttributeTypeImpl.DateTime, Order.Asc> getSubtypes() {
-                return super.getSubtypeVertices(DATETIME)
-                        .mapSorted(v -> AttributeTypeImpl.DateTime.of(graphMgr, v), attrType -> attrType.vertex, ASC);
-
+                return merge(
+                        iterateSorted(ASC, this),
+                        super.getSubtypeVertices(DATETIME).mapSorted(v ->
+                                AttributeTypeImpl.DateTime.of(graphMgr, v), attrType -> attrType.vertex, ASC
+                        )
+                );
             }
 
             @Override

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -19,7 +19,8 @@
 package com.vaticle.typedb.core.concept.type.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Entity;
 import com.vaticle.typedb.core.concept.thing.impl.EntityImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
@@ -33,7 +34,8 @@ import java.util.List;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_ROOT_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.ENTITY_TYPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.Root.ENTITY;
 
@@ -43,7 +45,7 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         super(graphMgr, vertex);
         if (vertex.encoding() != ENTITY_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
-                                               ENTITY_TYPE.root().label(), vertex.encoding().root().label()));
+                    ENTITY_TYPE.root().label(), vertex.encoding().root().label()));
         }
     }
 
@@ -69,22 +71,23 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     }
 
     @Override
-    public FunctionalIterator<EntityTypeImpl> getSubtypes() {
-        return iterate(graphMgr.schema().getSubtypes(vertex)).map(v -> of(graphMgr, v));
+    public Seekable<EntityTypeImpl, Order.Asc> getSubtypes() {
+        return iterateSorted(graphMgr.schema().getSubtypes(vertex), ASC)
+                .mapSorted(v -> of(graphMgr, v), entityType -> entityType.vertex, ASC);
     }
 
     @Override
-    public FunctionalIterator<EntityTypeImpl> getSubtypesExplicit() {
+    public Seekable<EntityTypeImpl, Order.Asc> getSubtypesExplicit() {
         return super.getSubtypesExplicit(v -> of(graphMgr, v));
     }
 
     @Override
-    public FunctionalIterator<EntityImpl> getInstances() {
+    public Seekable<EntityImpl, Order.Asc> getInstances() {
         return instances(EntityImpl::of);
     }
 
     @Override
-    public FunctionalIterator<EntityImpl> getInstancesExplicit() {
+    public Seekable<EntityImpl, Order.Asc> getInstancesExplicit() {
         return instancesExplicit(EntityImpl::of);
     }
 
@@ -106,10 +109,14 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     }
 
     @Override
-    public boolean isEntityType() { return true; }
+    public boolean isEntityType() {
+        return true;
+    }
 
     @Override
-    public EntityTypeImpl asEntityType() { return this; }
+    public EntityTypeImpl asEntityType() {
+        return this;
+    }
 
     private static class Root extends EntityTypeImpl {
 
@@ -119,7 +126,9 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         }
 
         @Override
-        public boolean isRoot() { return true; }
+        public boolean isRoot() {
+            return true;
+        }
 
         @Override
         public void setLabel(String label) {

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -27,16 +27,15 @@ import com.vaticle.typedb.core.concept.thing.impl.RelationImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RelationType;
 import com.vaticle.typedb.core.concept.type.RoleType;
+import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.edge.TypeEdge;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_ROOT_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.RELATION_ABSTRACT_ROLE;
@@ -46,7 +45,6 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.RE
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
-import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.RELATES;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.RELATION_TYPE;
@@ -68,8 +66,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     public static RelationTypeImpl of(GraphManager graphMgr, TypeVertex vertex) {
-        if (vertex.label().equals(RELATION.label()))
-            return new RelationTypeImpl.Root(graphMgr, vertex);
+        if (vertex.label().equals(RELATION.label())) return new RelationTypeImpl.Root(graphMgr, vertex);
         else return new RelationTypeImpl(graphMgr, vertex);
     }
 
@@ -171,22 +168,15 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     @Override
-    public FunctionalIterator<RoleTypeImpl> getRelates() {
-        FunctionalIterator<RoleTypeImpl> roles = vertex.outs().edge(RELATES).to().map(v -> RoleTypeImpl.of(graphMgr, v));
-        if (isRoot()) {
-            return roles;
-        } else {
-            assert getSupertype() != null;
-            Set<RoleTypeImpl> overridden = new HashSet<>();
-            overriddenRoles().forEachRemaining(overridden::add);
-            return link(roles, getSupertype().asRelationType().getRelates().filter(role -> !overridden.contains(role)));
-        }
+    public Seekable<RoleTypeImpl, Order.Asc> getRelates() {
+        return iterateSorted(graphMgr.schema().relatedRoleTypes(vertex), ASC)
+                .mapSorted(v -> RoleTypeImpl.of(graphMgr, v), roleType -> roleType.vertex, ASC);
     }
 
     @Override
-    public FunctionalIterator<RoleTypeImpl> getRelatesExplicit() {
-        FunctionalIterator<RoleTypeImpl> roles = vertex.outs().edge(RELATES).to().map(v -> RoleTypeImpl.of(graphMgr, v));
-        return roles;
+    public Seekable<RoleTypeImpl, Order.Asc> getRelatesExplicit() {
+        return vertex.outs().edge(RELATES).to()
+                .mapSorted(v -> RoleTypeImpl.of(graphMgr, v), roleType -> roleType.vertex, ASC);
     }
 
     @Override
@@ -234,9 +224,8 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     @Override
     public RoleTypeImpl getRelatesExplicit(String roleLabel) {
         TypeVertex roleTypeVertex = graphMgr.schema().getType(roleLabel, vertex.label());
-        if (roleTypeVertex != null) {
-            return RoleTypeImpl.of(graphMgr, roleTypeVertex);
-        } else return null;
+        if (roleTypeVertex != null) return RoleTypeImpl.of(graphMgr, roleTypeVertex);
+        else return null;
     }
 
     @Override
@@ -252,7 +241,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         if (!isRoot() && !isAbstract() && !getRelates().filter(r -> !r.getLabel().equals(ROLE.properLabel())).hasNext()) {
             exceptions.add(TypeDBException.of(RELATION_NO_ROLE, this.getLabel()));
         } else if (!isAbstract()) {
-            getRelates().filter(TypeImpl::isAbstract).forEachRemaining(
+            getRelates().filter(Type::isAbstract).forEachRemaining(
                     rt -> exceptions.add(TypeDBException.of(RELATION_ABSTRACT_ROLE, getLabel(), rt.getLabel()))
             );
         }

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -20,6 +20,8 @@ package com.vaticle.typedb.core.concept.type.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Relation;
 import com.vaticle.typedb.core.concept.thing.impl.RelationImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
@@ -43,8 +45,9 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.RE
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.RELATION_RELATES_ROLE_NOT_AVAILABLE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.RELATES;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.RELATION_TYPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.Root.RELATION;
@@ -103,22 +106,23 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     @Override
-    public FunctionalIterator<RelationTypeImpl> getSubtypes() {
-        return iterate(graphMgr.schema().getSubtypes(vertex)).map(v -> of(graphMgr, v));
+    public Seekable<RelationTypeImpl, Order.Asc> getSubtypes() {
+        return iterateSorted(graphMgr.schema().getSubtypes(vertex), ASC)
+                .mapSorted(v -> of(graphMgr, v), relationType -> relationType.vertex, ASC);
     }
 
     @Override
-    public FunctionalIterator<RelationTypeImpl> getSubtypesExplicit() {
+    public Seekable<RelationTypeImpl, Order.Asc> getSubtypesExplicit() {
         return super.getSubtypesExplicit(v -> of(graphMgr, v));
     }
 
     @Override
-    public FunctionalIterator<RelationImpl> getInstances() {
+    public Seekable<RelationImpl, Order.Asc> getInstances() {
         return instances(RelationImpl::of);
     }
 
     @Override
-    public FunctionalIterator<RelationImpl> getInstancesExplicit() {
+    public Seekable<RelationImpl, Order.Asc> getInstancesExplicit() {
         return instancesExplicit(RelationImpl::of);
     }
 

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -20,6 +20,8 @@ package com.vaticle.typedb.core.concept.type.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.concept.thing.Entity;
 import com.vaticle.typedb.core.concept.thing.impl.RoleImpl;
 import com.vaticle.typedb.core.concept.type.RoleType;
@@ -35,8 +37,9 @@ import java.util.Objects;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_ROOT_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.INVALID_UNDEFINE_RELATES_HAS_INSTANCES;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+import static com.vaticle.typedb.core.common.iterator.Iterators.Sorted.Seekable.iterateSorted;
 import static com.vaticle.typedb.core.common.iterator.Iterators.loop;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.SUB;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.ROLE_TYPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.Root.ROLE;
@@ -48,7 +51,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         assert vertex.encoding() == ROLE_TYPE;
         if (vertex.encoding() != ROLE_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
-                                               ROLE_TYPE.root().label(), vertex.encoding().root().label()));
+                    ROLE_TYPE.root().label(), vertex.encoding().root().label()));
         }
     }
 
@@ -90,12 +93,13 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     @Override
-    public FunctionalIterator<RoleTypeImpl> getSubtypes() {
-        return iterate(graphMgr.schema().getSubtypes(vertex)).map(v -> of(graphMgr, v));
+    public Seekable<RoleTypeImpl, Order.Asc> getSubtypes() {
+        return iterateSorted(graphMgr.schema().getSubtypes(vertex), ASC)
+                .mapSorted(v -> of(graphMgr, v), rt -> rt.vertex, ASC);
     }
 
     @Override
-    public FunctionalIterator<RoleTypeImpl> getSubtypesExplicit() {
+    public Seekable<RoleTypeImpl, Order.Asc> getSubtypesExplicit() {
         return super.getSubtypesExplicit(v -> of(graphMgr, v));
     }
 
@@ -105,13 +109,14 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     @Override
-    public FunctionalIterator<RelationTypeImpl> getRelationTypes() {
+    public Seekable<RelationTypeImpl, Order.Asc> getRelationTypes() {
         return getRelationType().getSubtypes().filter(r -> r.overriddenRoles().noneMatch(o -> o.equals(this)));
     }
 
     @Override
-    public FunctionalIterator<ThingTypeImpl> getPlayers() {
-        return vertex.ins().edge(Encoding.Edge.Type.PLAYS).from().map(v -> ThingTypeImpl.of(graphMgr, v));
+    public Seekable<ThingTypeImpl, Order.Asc> getPlayers() {
+        return vertex.ins().edge(Encoding.Edge.Type.PLAYS).from()
+                .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), thingType -> thingType.vertex, ASC);
     }
 
     @Override
@@ -129,7 +134,9 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     private FunctionalIterator<RoleImpl> getInstances() {
-        return instances(RoleImpl::of);
+        return getSubtypes().filter(t -> !t.isAbstract())
+                .flatMap(t -> graphMgr.data().getReadable(t.vertex))
+                .map(RoleImpl::of);
     }
 
     @Override
@@ -138,10 +145,14 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     }
 
     @Override
-    public boolean isRoleType() { return true; }
+    public boolean isRoleType() {
+        return true;
+    }
 
     @Override
-    public RoleTypeImpl asRoleType() { return this; }
+    public RoleTypeImpl asRoleType() {
+        return this;
+    }
 
     public RoleImpl create() {
         return create(false);
@@ -161,15 +172,23 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
-        public boolean isRoot() { return true; }
+        public boolean isRoot() {
+            return true;
+        }
 
         @Override
-        public void setLabel(String label) { throw exception(TypeDBException.of(ROOT_TYPE_MUTATION)); }
+        public void setLabel(String label) {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
 
         @Override
-        void unsetAbstract() { throw exception(TypeDBException.of(ROOT_TYPE_MUTATION)); }
+        void unsetAbstract() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
 
         @Override
-        void sup(RoleType superType) { throw exception(TypeDBException.of(ROOT_TYPE_MUTATION)); }
+        void sup(RoleType superType) {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
     }
 }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -110,7 +110,8 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     @Override
     public Seekable<RelationTypeImpl, Order.Asc> getRelationTypes() {
-        return getRelationType().getSubtypes().filter(r -> r.overriddenRoles().noneMatch(o -> o.equals(this)));
+        return iterateSorted(graphMgr.schema().relationsOfRoleType(vertex), ASC)
+                .mapSorted(v -> RelationTypeImpl.of(graphMgr, v), relType -> relType.vertex, ASC);
     }
 
     @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -40,10 +40,8 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -395,14 +395,9 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     @Override
     public Seekable<RoleType, Order.Asc> getPlays() {
         if (isRoot()) return emptySorted();
-        Set<TypeVertex> overridden = new HashSet<>();
-        vertex.outs().edge(Encoding.Edge.Type.PLAYS).overridden().filter(Objects::nonNull).forEachRemaining(overridden::add);
         assert getSupertype() != null;
-        return vertex.outs().edge(Encoding.Edge.Type.PLAYS).to()
-                .mapSorted(v -> (RoleType) RoleTypeImpl.of(graphMgr, v), roleType -> ((RoleTypeImpl) roleType).vertex, ASC)
-                .merge(
-                        getSupertype().getPlays().filter(rt -> !overridden.contains(((RoleTypeImpl) rt).vertex))
-                );
+        return iterateSorted(graphMgr.schema().playedRoleTypes(vertex), ASC)
+                .mapSorted(v -> RoleTypeImpl.of(graphMgr, v), roleType -> ((RoleTypeImpl) roleType).vertex, ASC);
     }
 
     @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -20,7 +20,6 @@ package com.vaticle.typedb.core.concept.type.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Seekable;
 import com.vaticle.typedb.core.common.parameters.Label;
@@ -33,7 +32,6 @@ import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.structure.RuleStructure;
-import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typeql.lang.TypeQL;
 

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -145,8 +145,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     }
 
     void validateDelete() {
-        TypeVertex type = graphMgr.schema().getType(getLabel());
-        FunctionalIterator<RuleStructure> rules = graphMgr.schema().rules().references().get(type);
+        FunctionalIterator<RuleStructure> rules = graphMgr.schema().rules().references().get(vertex);
         if (rules.hasNext()) {
             throw exception(TypeDBException.of(TYPE_REFERENCED_IN_RULES, getLabel(), rules.toList()));
         }

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -258,13 +258,13 @@ public class TypeGraph {
         Set<TypeVertex> overriddens = new HashSet<>();
         NavigableSet<TypeVertex> ownedAttributeTypes = new TreeSet<>();
         loop(owner, Objects::nonNull, o -> o.outs().edge(SUB).to().firstOrNull())
-                .flatMap(o -> {
+                .flatMap(sub -> {
                     FunctionalIterator<KeyValue<TypeVertex, TypeVertex>> ownsAndOverridden = isKey ?
-                            o.outs().edge(OWNS_KEY).toAndOverridden() :
-                            o.outs().edge(OWNS).toAndOverridden().link(o.outs().edge(OWNS_KEY).toAndOverridden());
+                            sub.outs().edge(OWNS_KEY).toAndOverridden() :
+                            sub.outs().edge(OWNS).toAndOverridden().link(sub.outs().edge(OWNS_KEY).toAndOverridden());
                     return ownsAndOverridden.map(e -> {
                         if (e.value() != null) overriddens.add(e.value());
-                        if (!overriddens.contains(e.key())) return e.key();
+                        if (sub.equals(owner) || !overriddens.contains(e.key())) return e.key();
                         else return null;
                     }).filter(Objects::nonNull);
                 }).toSet(ownedAttributeTypes);
@@ -331,9 +331,9 @@ public class TypeGraph {
             Set<TypeVertex> overriddens = new HashSet<>();
             NavigableSet<TypeVertex> roleTypes = new TreeSet<>();
             loop(player, Objects::nonNull, p -> p.outs().edge(SUB).to().firstOrNull())
-                    .flatMap(s -> s.outs().edge(PLAYS).toAndOverridden().map(e -> {
+                    .flatMap(sub -> sub.outs().edge(PLAYS).toAndOverridden().map(e -> {
                         if (e.value() != null) overriddens.add(e.value());
-                        if (!overriddens.contains(e.key())) return e.key();
+                        if (sub.equals(player) || !overriddens.contains(e.key())) return e.key();
                         else return null;
                     }).noNulls()).toSet(roleTypes);
             return roleTypes;
@@ -371,9 +371,9 @@ public class TypeGraph {
             Set<TypeVertex> overriddens = new HashSet<>();
             NavigableSet<TypeVertex> roleTypes = new TreeSet<>();
             loop(relation, Objects::nonNull, r -> r.outs().edge(SUB).to().firstOrNull())
-                    .flatMap(s -> s.outs().edge(RELATES).toAndOverridden().map(e -> {
+                    .flatMap(sub -> sub.outs().edge(RELATES).toAndOverridden().map(e -> {
                         if (e.value() != null) overriddens.add(e.value());
-                        if (!overriddens.contains(e.key())) return e.key();
+                        if (sub.equals(relation) || !overriddens.contains(e.key())) return e.key();
                         else return null;
                     }).noNulls()).toSet(roleTypes);
             return roleTypes;


### PR DESCRIPTION
## What is the goal of this PR?

We extend the Sorted+Seekable iterator APIs into the Concept API - where possible, Concepts now return Seekable iterators. Using these APIs, plus the new Seekable iterators from the Graph elements and the more general Type graph caches, we optimise Concept API operations.

## What are the changes implemented in this PR?

* Expose `Seekable` iterators in the Concept API
* `Thing` and `Type` concepts are now comparable to themselves
* Utilise Seekable iterators to optimise lookups where possible, particularly by using the new `findFirst(T)` method available on Seekable iterators
* Refactor `Type` classes to rely on the Type graph caches, which should help speed up validation for writes (20% attribute ownership loading improvment!)
* Fix bugs found in the Type graph cache that were brought up by forcing Concept API operations to use the cache as well - directly owned attributes/played roles/related roles that were overridden were being excluded from the cache of the owner. This was never found because the previous usages were not directly correctness related (eg. statistics)